### PR TITLE
Onion hash for signers image

### DIFF
--- a/contracts/mocks/LibBytesImpl.sol
+++ b/contracts/mocks/LibBytesImpl.sol
@@ -11,8 +11,8 @@ contract LibBytesImpl {
     return (_data, by);
   }
 
-  function readUint8Uint16(bytes calldata _data, uint256 _index) external pure returns (uint8, uint16, uint256) {
-    return _data.readUint8Uint16(_index);
+  function readFirstUint16(bytes calldata _data) external pure returns (uint16, uint256) {
+    return _data.readFirstUint16();
   }
 
   function readBoolUint8(bytes calldata _data, uint256 _index) external pure returns (bool, uint8, uint256) {
@@ -29,20 +29,5 @@ contract LibBytesImpl {
 
   function readBytes32(bytes calldata _data, uint256 _index) external pure returns (bytes32) {
     return _data.readBytes32(_index);
-  }
-
-  function writeUint16(bytes memory _dest, uint256 _index, uint16 _a) public pure returns (bytes memory, uint256) {
-    uint256 newIndex = _dest.writeUint16(_index, _a);
-    return (_dest, newIndex);
-  }
-
-  function writeUint8Address(
-    bytes memory _dest,
-    uint256 _index,
-    uint8 _a,
-    address _b
-  ) public pure returns (bytes memory, uint256) {
-    uint256 newIndex = _dest.writeUint8Address(_index, _a, _b);
-    return (_dest, newIndex);
   }
 }

--- a/contracts/modules/commons/ModuleAuthFixed.sol
+++ b/contracts/modules/commons/ModuleAuthFixed.sol
@@ -20,17 +20,17 @@ abstract contract ModuleAuthFixed is ModuleAuth {
 
   /**
    * @notice Validates the signature image with the salt used to deploy the contract
-   * @param _image Image of signature
+   * @param _imageHash Hash image of signature
    * @return true if the signature image is valid
    */
-  function _isValidImage(bytes memory _image) internal override view returns (bool) {
+  function _isValidImage(bytes32 _imageHash) internal override view returns (bool) {
     return address(
       uint256(
         keccak256(
           abi.encodePacked(
             byte(0xff),
             FACTORY,
-            keccak256(_image),
+            _imageHash,
             INIT_CODE_HASH
           )
         )

--- a/contracts/modules/commons/ModuleAuthUpgradable.sol
+++ b/contracts/modules/commons/ModuleAuthUpgradable.sol
@@ -26,10 +26,10 @@ abstract contract ModuleAuthUpgradable is ModuleBase, ModuleAuth {
   /**
    * @notice Validates the signature image with a valid image hash defined
    *   in the contract storage
-   * @param _image Image of signature
+   * @param _imageHash Hash image of signature
    * @return true if the signature image is valid
    */
-  function _isValidImage(bytes memory _image) internal override view returns (bool) {
-    return keccak256(_image) == _readBytes32(IMAGE_HASH_KEY);
+  function _isValidImage(bytes32 _imageHash) internal override view returns (bool) {
+    return _imageHash == _readBytes32(IMAGE_HASH_KEY);
   }
 }

--- a/contracts/utils/LibBytes.sol
+++ b/contracts/utils/LibBytes.sol
@@ -53,28 +53,23 @@ library LibBytes {
   |__________________________________*/
 
   /**
-   * @dev Reads consecutive uint8 and uint16 values.
+   * @dev Read firsts uint16 value.
    * @param data Byte array to be read.
-   * @param index Index in byte array of uint8 and uint16 values.
-   * @return a uint8 value of data at given index.
-   * @return b uint16 value of data at given index + 8.
+   * @return a uint16 value of data at index zero.
    * @return newIndex Updated index after reading the values.
    */
-  function readUint8Uint16(
-    bytes memory data,
-    uint256 index
+  function readFirstUint16(
+    bytes memory data
   ) internal pure returns (
-    uint8 a,
-    uint16 b,
+    uint16 a,
     uint256 newIndex
   ) {
     assembly {
-      let word := mload(add(index, add(32, data)))
-      a := shr(248, word)
-      b := and(shr(232, word), 0xffff)
-      newIndex := add(index, 3)
+      let word := mload(add(32, data))
+      a := shr(240, word)
+      newIndex := 2
     }
-    require(newIndex <= data.length, "LibBytes#readUint8Uint16: OUT_OF_BOUNDS");
+    require(2 <= data.length, "LibBytes#readFirstUint16: OUT_OF_BOUNDS");
   }
 
   /**
@@ -176,56 +171,5 @@ library LibBytes {
       result := mload(add(b, pos))
     }
     return result;
-  }
-
-
-  /***********************************|
-  |       Write Bytes Functions       |
-  |__________________________________*/
-
-  /**
-   * @dev Writes uint16 into bytes array.
-   * @param dest Bytes array to be written.
-   * @param index Index to start writing value.
-   * @param a Uint16 value to be written
-   * @return newIndex Updated index after writing the value.
-   */
-  function writeUint16(
-    bytes memory dest,
-    uint256 index,
-    uint16 a
-  ) internal pure returns (uint256 newIndex) {
-    assembly {
-      let mask240 := 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-      let indx := add(add(32, index), dest)
-      let prev := and(mload(indx), mask240)
-      mstore(indx, or(shl(240, a), prev))
-      newIndex := add(index, 2)
-    }
-    require(newIndex <= dest.length, "LibBytes#writeUint16: OUT_OF_BOUNDS");
-  }
-
-  /**
-   * @dev Writes consecutive uint8 and address into bytes array.
-   * @param dest Bytes array to be written.
-   * @param index Index to start writing value.
-   * @param a Uint8 value to be written
-   * @param b Address value to be written
-   * @return newIndex Updated index after writing the value.
-   */
-  function writeUint8Address(
-    bytes memory dest,
-    uint256 index,
-    uint8 a,
-    address b
-  ) internal pure returns (uint256 newIndex) {
-    assembly {
-      let mask88 := 0xffffffffffffffffffffff
-      let indx := add(add(index, 32), dest)
-      let prev := and(mload(indx), mask88)
-      mstore(indx, or(prev,or(shl(248, a), shl(88, b))))
-      newIndex := add(index, 21)
-    }
-    require(newIndex <= dest.length, "LibBytes#writeUint8Address: OUT_OF_BOUNDS");
   }
 }

--- a/src/tests/LibBytes.spec.ts
+++ b/src/tests/LibBytes.spec.ts
@@ -33,32 +33,20 @@ contract('LibBytes', (accounts: string[]) => {
     })
   })
 
-  describe('readUint8Uint16', () => {
-    it('Should read uint8 and uint16 at index zero', async () => {
-      const res = await libBytes.readUint8Uint16('0x03021e4453120a', 0)
-      expect(res[0]).to.eq.BN(3)
-      expect(res[1]).to.eq.BN(542)
-      expect(res[2]).to.eq.BN(3)
+  describe('readFirstUint16', () => {
+    it('Should read first uint16', async () => {
+      const res = await libBytes.readFirstUint16('0x03021e4453120a')
+      expect(res[0]).to.eq.BN(770)
+      expect(res[1]).to.eq.BN(2)
     })
-    it('Should read uint8 and uint16 at given index', async () => {
-      const res = await libBytes.readUint8Uint16('0x5a9c2a6519d401d3', 3)
-      expect(res[0]).to.eq.BN(101)
-      expect(res[1]).to.eq.BN(6612)
-      expect(res[2]).to.eq.BN(6)
+    it('Should read first uint16 of 2 byte array', async () => {
+      const res = await libBytes.readFirstUint16('0xff0a')
+      expect(res[0]).to.eq.BN(65290)
+      expect(res[1]).to.eq.BN(2)
     })
-    it('Should read uint8 and uint16 at last index', async () => {
-      const res = await libBytes.readUint8Uint16('0x02010004', 1)
-      expect(res[0]).to.eq.BN(1)
-      expect(res[1]).to.eq.BN(4)
-      expect(res[2]).to.eq.BN(4)
-    })
-    it('Should fail read uint8 and uint16 out of bounds', async () => {
-      const tx = libBytes.readUint8Uint16('0x5a9c', 0)
-      await expect(tx).to.be.rejectedWith('LibBytes#readUint8Uint16: OUT_OF_BOUNDS')
-    })
-    it('Should fail read uint8 and uint16 fully out of bounds', async () => {
-      const tx = libBytes.readUint8Uint16('0x5a9ca2', 12)
-      await expect(tx).to.be.rejectedWith('LibBytes#readUint8Uint16: OUT_OF_BOUNDS')
+    it('Should fail first uint16 out of bounds', async () => {
+      const tx = libBytes.readFirstUint16('0x5a')
+      await expect(tx).to.be.rejectedWith('LibBytes#readFirstUint16: OUT_OF_BOUNDS')
     })
   })
 
@@ -202,120 +190,6 @@ contract('LibBytes', (accounts: string[]) => {
     it('Should fail read bytes32 totally out of bounds', async () => {
       const tx = libBytes.readBytes32("0x010203", 3145)
       await expect(tx).to.be.rejectedWith('LibBytes#readBytes32: GREATER_OR_EQUAL_TO_32_LENGTH_REQUIRED')
-    })
-  })
-
-  describe('writeUint16', () => {
-    it('Should write uint16 at index zero', async () => {
-      const res = await libBytes.writeUint16("0x0000", 0, 42)
-      expect(res[0]).to.be.equal("0x002a")
-      expect(res[1]).to.eq.BN(2)
-    })
-    it('Should write uint16 at given index', async () => {
-      const res = await libBytes.writeUint16("0x010200000000", 2, 8843)
-      expect(res[0]).to.be.equal("0x0102228b0000")
-      expect(res[1]).to.eq.BN(4)
-    })
-    it('Should write uint16 between bytes', async () => {
-      const res = await libBytes.writeUint16("0x010200000304", 2, 8843)
-      expect(res[0]).to.be.equal("0x0102228b0304")
-      expect(res[1]).to.eq.BN(4)
-    })
-    it('Should write uint16 at last index', async () => {
-      const res = await libBytes.writeUint16("0x110000", 1, 9999)
-      expect(res[0]).to.be.equal("0x11270f")
-      expect(res[1]).to.eq.BN(3)
-    })
-    it('Should overwrite uint16 between bytes', async () => {
-      const res = await libBytes.writeUint16("0x010211110304", 2, 8843)
-      expect(res[0]).to.be.equal("0x0102228b0304")
-      expect(res[1]).to.eq.BN(4)
-    })
-    it('Should fail write uint16 out of bounds', async () => {
-      const tx = libBytes.writeUint16("0x110000", 2, 9999)
-      await expect(tx).to.be.rejectedWith('LibBytes#writeUint16: OUT_OF_BOUNDS')
-    })
-    it('Should fail write uint16 totally out of bounds', async () => {
-      const tx = libBytes.writeUint16("0x110000", 22, 9999)
-      await expect(tx).to.be.rejectedWith('LibBytes#writeUint16: OUT_OF_BOUNDS')
-    })
-  })
-
-  describe('writeUint8Address', () => {
-    let addr
-    let uint8
-    beforeEach(async () => {
-      addr = web3.utils.randomHex(20)
-      uint8 = web3.utils.randomHex(1)
-    })
-    it('Should write uint8 and address at index zero', async () => {
-      const res = await libBytes.writeUint8Address(
-        "0x" + "00".repeat(21) + "0000", 0, uint8, addr
-      )
-
-      const expected = uint8.concat(addr.slice(2)).concat("0000")
-
-      expect(res[0]).to.be.equal(expected)
-      expect(res[1]).to.eq.BN(21)
-    })
-    it('Should write uint8 and address at given index', async () => {
-      const res = await libBytes.writeUint8Address(
-        "0x0102" + "00".repeat(21) + "0000", 2, uint8, addr
-      )
-
-      const expected = "0x0102"
-        .concat(uint8.slice(2))
-        .concat(addr.slice(2))
-        .concat("0000")
-
-      expect(res[0]).to.be.equal(expected)
-      expect(res[1]).to.eq.BN(23)
-    })
-    it('Should write uint8 and address between bytes', async () => {
-      const res = await libBytes.writeUint8Address(
-        "0x010203" + "00".repeat(21) + "9988", 3, uint8, addr
-      )
-
-      const expected = "0x010203"
-        .concat(uint8.slice(2))
-        .concat(addr.slice(2))
-        .concat("9988")
-
-      expect(res[0]).to.be.equal(expected)
-      expect(res[1]).to.eq.BN(24)
-    })
-    it('Should write uint8 and address at last index', async () => {
-      const res = await libBytes.writeUint8Address(
-        "0xaa23abcd" + "00".repeat(21), 4, uint8, addr
-      )
-
-      const expected = "0xaa23abcd"
-        .concat(uint8.slice(2))
-        .concat(addr.slice(2))
-
-      expect(res[0]).to.be.equal(expected)
-      expect(res[1]).to.eq.BN(25)
-    })
-    it('Should overwrite uint8 and address between bytes', async () => {
-      const res = await libBytes.writeUint8Address(
-        "0x45a933" + web3.utils.randomHex(21).slice(2) + "0a4b", 3, uint8, addr
-      )
-
-      const expected = "0x45a933"
-        .concat(uint8.slice(2))
-        .concat(addr.slice(2))
-        .concat("0a4b")
-
-      expect(res[0]).to.be.equal(expected)
-      expect(res[1]).to.eq.BN(24)
-    })
-    it('Should fail write uint8 and address out of bounds', async () => {
-      const tx = libBytes.writeUint8Address("0xaa23abcd" + "00".repeat(21), 5, uint8, addr)
-      await expect(tx).to.be.rejectedWith('LibBytes#writeUint8Address: OUT_OF_BOUNDS')
-    })
-    it('Should fail write uint8 and address totally out of bounds', async () => {
-      const tx = libBytes.writeUint8Address("0xaa23abcd" + "00".repeat(21), 125, uint8, addr)
-      await expect(tx).to.be.rejectedWith('LibBytes#writeUint8Address: OUT_OF_BOUNDS')
     })
   })
 })

--- a/src/tests/utils/helpers.ts
+++ b/src/tests/utils/helpers.ts
@@ -184,8 +184,8 @@ export async function walletMultiSign(
   )
 
   return ethers.utils.solidityPack(
-    ['uint8', 'uint16', ...Array(accounts.length).fill('bytes')],
-    [accounts.length, threshold, ...accountBytes]
+    ['uint16', ...Array(accounts.length).fill('bytes')],
+    [threshold, ...accountBytes]
   )
 }
 
@@ -263,15 +263,16 @@ export function encodeImageHash(
   }[]
 ) {
   const sorted = accounts.sort((a, b) => compareAddr(a.address, b.address))
+  let imageHash = ethers.utils.solidityPack(['uint256'], [threshold])
 
-  const weightedAddresses = sorted.map((a) => ethers.utils.solidityPack(
-    ['uint8', 'address'], [a.weight, a.address]
-  ))
-
-  const image = ethers.utils.solidityPack(
-    ['uint16', ...Array(sorted.length).fill('bytes21')],
-    [threshold, ...weightedAddresses]
+  sorted.forEach((a) => 
+    imageHash = ethers.utils.keccak256(
+      ethers.utils.defaultAbiCoder.encode(
+        ['bytes32', 'uint8', 'address'],
+        [imageHash, a.weight, a.address]
+      )
+    )
   )
 
-  return ethers.utils.keccak256(image)
+  return imageHash
 }

--- a/typings/contracts/LibBytesImpl.d.ts
+++ b/typings/contracts/LibBytesImpl.d.ts
@@ -16,8 +16,8 @@ interface LibBytesImplInterface extends Interface {
       encode([_data]: [Arrayish]): string;
     }>;
 
-    readUint8Uint16: TypedFunctionDescription<{
-      encode([_data, _index]: [Arrayish, BigNumberish]): string;
+    readFirstUint16: TypedFunctionDescription<{
+      encode([_data]: [Arrayish]): string;
     }>;
 
     readBoolUint8: TypedFunctionDescription<{
@@ -34,23 +34,6 @@ interface LibBytesImplInterface extends Interface {
 
     readBytes32: TypedFunctionDescription<{
       encode([_data, _index]: [Arrayish, BigNumberish]): string;
-    }>;
-
-    writeUint16: TypedFunctionDescription<{
-      encode([_dest, _index, _a]: [
-        Arrayish,
-        BigNumberish,
-        BigNumberish
-      ]): string;
-    }>;
-
-    writeUint8Address: TypedFunctionDescription<{
-      encode([_dest, _index, _a, _b]: [
-        Arrayish,
-        BigNumberish,
-        BigNumberish,
-        string
-      ]): string;
     }>;
   };
 
@@ -81,13 +64,11 @@ export class LibBytesImpl extends Contract {
       1: string;
     }>;
 
-    readUint8Uint16(
-      _data: Arrayish,
-      _index: BigNumberish
+    readFirstUint16(
+      _data: Arrayish
     ): Promise<{
       0: number;
-      1: number;
-      2: BigNumber;
+      1: BigNumber;
     }>;
 
     readBoolUint8(
@@ -116,25 +97,6 @@ export class LibBytesImpl extends Contract {
     }>;
 
     readBytes32(_data: Arrayish, _index: BigNumberish): Promise<string>;
-
-    writeUint16(
-      _dest: Arrayish,
-      _index: BigNumberish,
-      _a: BigNumberish
-    ): Promise<{
-      0: string;
-      1: BigNumber;
-    }>;
-
-    writeUint8Address(
-      _dest: Arrayish,
-      _index: BigNumberish,
-      _a: BigNumberish,
-      _b: string
-    ): Promise<{
-      0: string;
-      1: BigNumber;
-    }>;
   };
 
   popLastByte(
@@ -144,13 +106,11 @@ export class LibBytesImpl extends Contract {
     1: string;
   }>;
 
-  readUint8Uint16(
-    _data: Arrayish,
-    _index: BigNumberish
+  readFirstUint16(
+    _data: Arrayish
   ): Promise<{
     0: number;
-    1: number;
-    2: BigNumber;
+    1: BigNumber;
   }>;
 
   readBoolUint8(
@@ -180,31 +140,12 @@ export class LibBytesImpl extends Contract {
 
   readBytes32(_data: Arrayish, _index: BigNumberish): Promise<string>;
 
-  writeUint16(
-    _dest: Arrayish,
-    _index: BigNumberish,
-    _a: BigNumberish
-  ): Promise<{
-    0: string;
-    1: BigNumber;
-  }>;
-
-  writeUint8Address(
-    _dest: Arrayish,
-    _index: BigNumberish,
-    _a: BigNumberish,
-    _b: string
-  ): Promise<{
-    0: string;
-    1: BigNumber;
-  }>;
-
   filters: {};
 
   estimate: {
     popLastByte(_data: Arrayish): Promise<BigNumber>;
 
-    readUint8Uint16(_data: Arrayish, _index: BigNumberish): Promise<BigNumber>;
+    readFirstUint16(_data: Arrayish): Promise<BigNumber>;
 
     readBoolUint8(_data: Arrayish, _index: BigNumberish): Promise<BigNumber>;
 
@@ -213,18 +154,5 @@ export class LibBytesImpl extends Contract {
     readBytes66(_data: Arrayish, _index: BigNumberish): Promise<BigNumber>;
 
     readBytes32(_data: Arrayish, _index: BigNumberish): Promise<BigNumber>;
-
-    writeUint16(
-      _dest: Arrayish,
-      _index: BigNumberish,
-      _a: BigNumberish
-    ): Promise<BigNumber>;
-
-    writeUint8Address(
-      _dest: Arrayish,
-      _index: BigNumberish,
-      _a: BigNumberish,
-      _b: string
-    ): Promise<BigNumber>;
   };
 }


### PR DESCRIPTION
- Reduces code complexity by not writing a bytes array
- Increases the cost for multisig signature validation
- Reduces memory usage
- Removes total number of signers from signature

Packed image hash (prev):
```
 -> relay 1/1 transaction runs: 1000 cost min: 62866 max: 62890 avg: 62886
 -> relay 2/5 transaction runs: 1000 cost min: 73374 max: 73446 avg: 73436
 -> relay 255/255 transaction runs: 100 cost min: 1998397 max: 1998901 avg: 1998696
```

Onion image hash (new):
```
-> relay 1/1 transaction runs: 1000 cost min: 62711 max: 62747 avg: 62743
-> relay 2/5 transaction runs: 1000 cost min: 74636 max: 74684 avg: 74674
-> relay 255/255 transaction runs: 100 cost min: 2095527 max: 2095971 avg: 2095780
```

This proposal is an alternative to #33