### PR TITLE
Undo comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,22 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    name: Is latest build commited?
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - uses: actions/cache@master
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+      - run: yarn test
+      - run: git diff --exit-code

--- a/src/contracts/modules/GuestModule.sol
+++ b/src/contracts/modules/GuestModule.sol
@@ -18,11 +18,11 @@ import "../interfaces/IERC1271Wallet.sol";
 
 
 /**
- * GuestModule implements an Sequence wallet without signatures, nonce or replay protection.
+ * GuestModule implements an Arcadeum wallet without signatures, nonce or replay protection.
  * executing transactions using this wallet is not an authenticated process, and can be done by any address.
  *
  * @notice This contract is completely public with no security, designed to execute pre-signed transactions
- *   and use Sequence tools without using the wallets.
+ *   and use Arcadeum tools without using the wallets.
  */
 contract GuestModule is
   ModuleAuth,

--- a/src/contracts/modules/MainModule.sol
+++ b/src/contracts/modules/MainModule.sol
@@ -18,7 +18,7 @@ import "../interfaces/IERC1271Wallet.sol";
 
 
 /**
- * @notice Contains the core functionality Sequence wallets will inherit.
+ * @notice Contains the core functionality arcadeum wallets will inherit.
  * @dev If using a new main module, developpers must ensure that all inherited
  *      contracts by the mainmodule don't conflict and are accounted for to be
  *      supported by the supportsInterface method.

--- a/src/contracts/modules/MainModuleUpgradable.sol
+++ b/src/contracts/modules/MainModuleUpgradable.sol
@@ -10,7 +10,7 @@ import "./commons/ModuleCreator.sol";
 
 
 /**
- * @notice Contains the core functionality Sequence wallets will inherit with
+ * @notice Contains the core functionality arcadeum wallets will inherit with
  *         the added functionality that the main-module can be changed.
  * @dev If using a new main module, developpers must ensure that all inherited
  *      contracts by the mainmodule don't conflict and are accounted for to be


### PR DESCRIPTION
Comments are included on the metadata of the contracts, if we change them we also change the bytecode of the contract and thus we final addresses of the configuration and the user wallets.

In order to update these comments we need to add versioning and define a protocol for config updates.

I also added a task that builds the contracts and checks if there are uncommitted artifacts.