### PR TITLE
V2 - 3 bytes size for signatures

### DIFF
--- a/contracts/mocks/LibBytesPointerImpl.sol
+++ b/contracts/mocks/LibBytesPointerImpl.sol
@@ -26,6 +26,16 @@ contract LibBytesPointerImpl {
     return LibBytesPointer.readUint16(data, index);
   }
 
+  function readUint24(
+    bytes calldata data,
+    uint256 index
+  ) external pure returns (
+    uint24 a,
+    uint256 newPointer
+  ) {
+    return LibBytesPointer.readUint24(data, index);
+  }
+
   function readUint64(
     bytes calldata data,
     uint256 index

--- a/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
+++ b/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
@@ -101,7 +101,7 @@ library SequenceBaseSig {
 
           // Read signature size
           uint256 size;
-          (size, rindex) = _signature.readUint16(rindex);
+          (size, rindex) = _signature.readUint24(rindex);
 
           // Read dynamic size signature
           uint256 nrindex = rindex + size;

--- a/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
+++ b/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
@@ -130,7 +130,7 @@ library SequenceBaseSig {
         if (flag == FLAG_BRANCH) {
           // Enter a branch of the signature merkle tree
           uint256 size;
-          (size, rindex) = _signature.readUint16(rindex);
+          (size, rindex) = _signature.readUint24(rindex);
           uint256 nrindex = rindex + size;
 
           uint256 nweight; bytes32 node;

--- a/contracts/modules/commons/submodules/auth/SequenceChainedSig.sol
+++ b/contracts/modules/commons/submodules/auth/SequenceChainedSig.sol
@@ -58,8 +58,8 @@ abstract contract SequenceChainedSig is IModuleAuth, ModuleSelfAuth {
     // First signature out of the loop
     //
 
-    // First uint16 is the size of the signature
-    (sigSize, rindex) = _signature.readUint16(rindex);
+    // First uint24 is the size of the signature
+    (sigSize, rindex) = _signature.readUint24(rindex);
     uint256 nrindex = sigSize + rindex;
 
     (
@@ -95,8 +95,8 @@ abstract contract SequenceChainedSig is IModuleAuth, ModuleSelfAuth {
 
       prevCheckpoint = checkpoint;
 
-      // First uint16 is the size of the signature
-      (sigSize, rindex) = _signature.readUint16(rindex);
+      // First uint24 is the size of the signature
+      (sigSize, rindex) = _signature.readUint24(rindex);
       nrindex = sigSize + rindex;
 
       (

--- a/contracts/utils/LibBytesPointer.sol
+++ b/contracts/utils/LibBytesPointer.sol
@@ -60,6 +60,20 @@ library LibBytesPointer {
     }
   }
 
+  function readUint24(
+    bytes calldata data,
+    uint256 index
+  ) internal pure returns (
+    uint24 a,
+    uint256 newPointer
+  ) {
+    assembly {
+      let word := calldataload(add(index, data.offset))
+      a := and(shr(232, word), 0xffffff)
+      newPointer := add(index, 3)
+    }
+  }
+
   function readUint64(
     bytes calldata data,
     uint256 index

--- a/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
@@ -152,7 +152,7 @@ contract SequenceBaseSigTest is AdvTest {
         if (op == 1) {
           signature = abi.encodePacked(signature, FLAG_SIGNATURE, randomWeight, sigpart);
         } else {
-          signature = abi.encodePacked(signature, FLAG_DYNAMIC_SIGNATURE, randomWeight, addr, uint16(sigpart.length), sigpart);
+          signature = abi.encodePacked(signature, FLAG_DYNAMIC_SIGNATURE, randomWeight, addr, uint24(sigpart.length), sigpart);
         }
       }
 
@@ -196,7 +196,7 @@ contract SequenceBaseSigTest is AdvTest {
         if (op == 1) {
           signature = abi.encodePacked(FLAG_SIGNATURE, randomWeight, sigpart, signature);
         } else {
-          signature = abi.encodePacked(FLAG_DYNAMIC_SIGNATURE, randomWeight, addr, uint16(sigpart.length), sigpart, signature);
+          signature = abi.encodePacked(FLAG_DYNAMIC_SIGNATURE, randomWeight, addr, uint24(sigpart.length), sigpart, signature);
         }
       }
 

--- a/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
@@ -175,7 +175,7 @@ contract SequenceBaseSigTest is AdvTest {
 
     for (uint256 i = 0; i < size; i++) {
       if (i != 0) {
-        signature = abi.encodePacked(FLAG_BRANCH, uint16(signature.length), signature);
+        signature = abi.encodePacked(FLAG_BRANCH, uint24(signature.length), signature);
       }
 
       _pks[i] = boundPk(_pks[i]);

--- a/foundry_test/modules/commons/submodules/auth/SequenceChainedSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceChainedSig.t.sol
@@ -163,7 +163,7 @@ contract SequenceChainedSigTest is AdvTest {
       );
 
       nextDigest = lib.hashSetImagehashStruct(_steps[i].imageHash, checkpoint);
-      signature = abi.encodePacked(signature, uint16(_steps[i].signature.length), _steps[i].signature);
+      signature = abi.encodePacked(signature, uint24(_steps[i].signature.length), _steps[i].signature);
     }
 
     vm.prank(address(lib));
@@ -215,7 +215,7 @@ contract SequenceChainedSigTest is AdvTest {
       );
 
       nextDigest = lib.hashSetImagehashStruct(_steps[i].imageHash, checkpoint);
-      signature = abi.encodePacked(signature, uint16(_steps[i].signature.length), _steps[i].signature);
+      signature = abi.encodePacked(signature, uint24(_steps[i].signature.length), _steps[i].signature);
     }
 
     vm.expectRevert(abi.encodeWithSignature('LowWeightChainedSignature(bytes,uint256,uint256)', _steps[_badi].signature, _steps[_badi].threshold, _steps[_badi].weight));
@@ -265,7 +265,7 @@ contract SequenceChainedSigTest is AdvTest {
       );
 
       nextDigest = lib.hashSetImagehashStruct(_steps[i].imageHash, checkpoint);
-      signature = abi.encodePacked(signature, uint16(_steps[i].signature.length), _steps[i].signature);
+      signature = abi.encodePacked(signature, uint24(_steps[i].signature.length), _steps[i].signature);
     }
 
     vm.prank(address(lib));

--- a/foundry_test/utils/LibBytesPointer.t.sol
+++ b/foundry_test/utils/LibBytesPointer.t.sol
@@ -26,6 +26,10 @@ contract LibBytesPointerImp {
     return _data.readUint16(_index);
   }
 
+  function readUint24(bytes calldata _data, uint256 _index) external pure returns (uint24, uint256) {
+    return _data.readUint24(_index);
+  }
+
   function readUint64(bytes calldata _data, uint256 _index) external pure returns (uint64, uint256) {
     return _data.readUint64(_index);
   }
@@ -84,6 +88,18 @@ contract LibBytesPointerTest is AdvTest {
   function test_readUint16_OutOfBounds(bytes calldata _data, uint256 _pointer) external {
     (, uint256 newPointer) = lib.readUint16(_data, _pointer);
     unchecked { assertEq(newPointer, _pointer + 2); }
+  }
+
+  function test_readUint24(bytes calldata _prefix, uint24 _data, bytes calldata _sufix) external {
+    bytes memory combined = abi.encodePacked(_prefix, _data, _sufix);
+    (uint256 actual, uint256 newPointer) = lib.readUint24(combined, _prefix.length);
+    assertEq(actual, _data);
+    assertEq(newPointer, _prefix.length + 3);
+  }
+
+  function test_readUint24_OutOfBounds(bytes calldata _data, uint256 _pointer) external {
+    (, uint256 newPointer) = lib.readUint24(_data, _pointer);
+    unchecked { assertEq(newPointer, _pointer + 3); }
   }
 
   function test_readUint64(bytes calldata _prefix, uint64 _data, bytes calldata _sufix) external {

--- a/test/ChainedSignatures.spec.ts
+++ b/test/ChainedSignatures.spec.ts
@@ -22,12 +22,12 @@ contract('Chained signatures', (accounts: string[]) => {
 
   const chain = (top: string, ...rest: { sig: string, checkpoint: ethers.BigNumberish }[]) => {
     const encodedRest = ethers.utils.solidityPack(
-      rest.map(() => ['uint64', 'uint16', 'bytes']).flat(),
+      rest.map(() => ['uint64', 'uint24', 'bytes']).flat(),
       rest.map((r) => [r.checkpoint, ethers.utils.arrayify(r.sig).length, r.sig]).flat()
     )
 
     return ethers.utils.solidityPack(
-      ['uint8', 'uint16', 'bytes', 'bytes'],
+      ['uint8', 'uint24', 'bytes', 'bytes'],
       [3, ethers.utils.arrayify(top).length, top, encodedRest]
     )
   }

--- a/test/LibBytes.spec.ts
+++ b/test/LibBytes.spec.ts
@@ -99,6 +99,36 @@ contract('LibBytes', () => {
     })
   })
 
+  describe('readUint24', () => {
+    it('Should read uint24 at index zero', async () => {
+      const res = await libBytesPointer.readUint24('0x5202fa', 0)
+      expect(res[0]).to.equal(5374714)
+      expect(res[1]).to.equal(3)
+    })
+    it('Should read uint24 at given index', async () => {
+      const res = await libBytesPointer.readUint24('0x5202f7220c', 2)
+      expect(res[0]).to.equal(16196108)
+      expect(res[1]).to.equal(5)
+    })
+    it('Should read uint24 at last index', async () => {
+      const res = await libBytesPointer.readUint24('0x021f2b00', 1)
+      expect(res[0]).to.equal(2042624)
+      expect(res[1]).to.equal(4)
+    })
+    it('Should read zeros uint24 out of bounds', async () => {
+      const res1 = await libBytesPointer.readUint24('0xf598', 0)
+      const res2 = await libBytesPointer.readUint24('0xf59800', 0)
+      expect(res1[0]).to.equal(16095232)
+      expect(res1[0]).to.equal(res2[0])
+      expect(res1[1]).to.equal(3)
+    })
+    it('Should read zeros uint24 fully out of bounds', async () => {
+      const res = await libBytesPointer.readUint24('0x5a9ca221', 12)
+      expect(res[0]).to.equal(0)
+      expect(res[1]).to.equal(15)
+    })
+  })
+
   describe('readUint64', () => {
     it('Should read uint64 at index zero', async () => {
       const res = await libBytesPointer.readUint64('0xc1725050681dcb2a', 0)

--- a/test/utils/sequence.ts
+++ b/test/utils/sequence.ts
@@ -490,7 +490,7 @@ export class SignatureConstructor {
         case SignaturePartType.Branch:
           const branch = ethers.utils.arrayify(member.value ?? [])
           result = ethers.utils.solidityPack(
-            ['bytes', 'uint8', 'uint16', 'bytes'],
+            ['bytes', 'uint8', 'uint24', 'bytes'],
             [result, SignaturePartType.Branch, branch.length, branch]
           )
           break

--- a/test/utils/sequence.ts
+++ b/test/utils/sequence.ts
@@ -475,7 +475,7 @@ export class SignatureConstructor {
         case SignaturePartType.Dynamic:
           const signature = ethers.utils.arrayify(member.value ?? [])
           result = ethers.utils.solidityPack(
-            ['bytes', 'uint8', 'uint8', 'address', 'uint16', 'bytes'],
+            ['bytes', 'uint8', 'uint8', 'address', 'uint24', 'bytes'],
             [result, SignaturePartType.Dynamic, member.weight, member.address, signature.length, signature]
           )
           break;


### PR DESCRIPTION
- Use 3 bytes for dynamic signatures
- Use 3 bytes for signature branches
- Use 3 bytes for chained signatures