### PR TITLE
Integrate checkpoint into imagehash

### DIFF
--- a/contracts/mocks/LibBytesImpl.sol
+++ b/contracts/mocks/LibBytesImpl.sol
@@ -24,4 +24,13 @@ contract LibBytesImpl {
   ) {
     return LibBytes.readUint8(data, index);
   }
+
+  function readUint32(
+    bytes calldata data,
+    uint256 index
+  ) external pure returns (
+    uint32 a
+  ) {
+    return LibBytes.readUint32(data, index);
+  }
 }

--- a/contracts/modules/commons/ModuleAuth.sol
+++ b/contracts/modules/commons/ModuleAuth.sol
@@ -38,29 +38,30 @@ abstract contract ModuleAuth is
     uint256 threshold,
     uint256 weight,
     bytes32 imageHash,
-    bytes32 subDigest
+    bytes32 subDigest,
+    uint256 checkpoint
   ) {
     bytes1 signatureType = _signature[0];
 
     if (signatureType == LEGACY_TYPE) {
       // networkId digest + base recover
       subDigest = SequenceBaseSig.subDigest(_digest);
-      (threshold, weight, imageHash) = SequenceBaseSig.recover(subDigest, _signature);
-      return (threshold, weight, imageHash, subDigest);
+      (threshold, weight, imageHash, checkpoint) = SequenceBaseSig.recover(subDigest, _signature);
+      return (threshold, weight, imageHash, subDigest, checkpoint);
     }
 
     if (signatureType == DYNAMIC_TYPE) {
       // noChainId digest + dynamic recovery
       subDigest = SequenceBaseSig.subDigest(_digest);
-      (threshold, weight, imageHash) = SequenceDynamicSig.recover(subDigest, _signature);
-      return (threshold, weight, imageHash, subDigest);
+      (threshold, weight, imageHash, checkpoint) = SequenceDynamicSig.recover(subDigest, _signature);
+      return (threshold, weight, imageHash, subDigest, checkpoint);
     }
 
     if (signatureType == NO_CHAIN_ID_TYPE) {
       // networkId digest + dynamic recover
       subDigest = SequenceNoChainIdSig.subDigest(_digest);
-      (threshold, weight, imageHash) = SequenceDynamicSig.recover(subDigest, _signature);
-      return (threshold, weight, imageHash, subDigest);
+      (threshold, weight, imageHash, checkpoint) = SequenceDynamicSig.recover(subDigest, _signature);
+      return (threshold, weight, imageHash, subDigest, checkpoint);
     }
 
     if (signatureType == CHAINED_TYPE) {
@@ -80,7 +81,7 @@ abstract contract ModuleAuth is
     bytes32 subDigest
   ) {
     uint256 threshold; uint256 weight; bytes32 imageHash;
-    (threshold, weight, imageHash, subDigest) = signatureRecovery(_digest, _signature);
+    (threshold, weight, imageHash, subDigest,) = signatureRecovery(_digest, _signature);
     isValid = weight >= threshold && _isValidImage(imageHash);
   }
 

--- a/contracts/modules/commons/interfaces/IModuleAuth.sol
+++ b/contracts/modules/commons/interfaces/IModuleAuth.sol
@@ -27,7 +27,8 @@ abstract contract IModuleAuth {
     uint256 threshold,
     uint256 weight,
     bytes32 imageHash,
-    bytes32 subDigest
+    bytes32 subDigest,
+    uint256 checkpoint
   );
 
   /**

--- a/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
+++ b/contracts/modules/commons/submodules/auth/SequenceBaseSig.sol
@@ -168,14 +168,18 @@ library SequenceBaseSig {
   ) internal view returns (
     uint256 threshold,
     uint256 weight,
-    bytes32 imageHash
+    bytes32 imageHash,
+    uint256 checkpoint
   ) {
     unchecked {
-      (weight, imageHash) = recoverBranch(_subDigest, _signature[2:]);
+      (weight, imageHash) = recoverBranch(_subDigest, _signature[6:]);
 
       // Threshold is the top-most node (but first on the signature)
       threshold = LibBytes.readFirstUint16(_signature);
+      checkpoint = LibBytes.readUint32(_signature, 2);
+
       imageHash = LibOptim.fkeccak256(imageHash, bytes32(threshold));
+      imageHash = LibOptim.fkeccak256(imageHash, bytes32(checkpoint));
     }
   }
 }

--- a/contracts/modules/commons/submodules/auth/SequenceDynamicSig.sol
+++ b/contracts/modules/commons/submodules/auth/SequenceDynamicSig.sol
@@ -11,7 +11,8 @@ library SequenceDynamicSig {
   ) internal view returns (
     uint256 threshold,
     uint256 weight,
-    bytes32 imageHash
+    bytes32 imageHash,
+    uint256 checkpoint
   ) {
     return SequenceBaseSig.recover(_subDigest, _signature[1:]);
   }

--- a/contracts/utils/LibBytes.sol
+++ b/contracts/utils/LibBytes.sol
@@ -36,4 +36,16 @@ library LibBytes {
       a := shr(240, word)
     }
   }
+
+  function readUint32(
+    bytes calldata data,
+    uint256 index
+  ) internal pure returns (
+    uint32 a
+  ) {
+    assembly {
+      let word := calldataload(add(index, data.offset))
+      a := shr(224, word)
+    }
+  }
 }

--- a/foundry_test/modules/commons/Implementation.t.sol
+++ b/foundry_test/modules/commons/Implementation.t.sol
@@ -47,6 +47,9 @@ contract ImplementationTest is AdvTest {
     _imp = boundNoSys(_imp);
     _imp2 = boundNoSys(_imp2);
 
+    _imp = boundDiff(_imp, address(factory));
+    _imp2 = boundDiff(_imp2, address(factory));
+
     vm.etch(_imp, address(new ImplementationImp()).code);
     address wallet = factory.deploy(_imp, _salt);
 

--- a/foundry_test/modules/commons/ModuleCalls.t.sol
+++ b/foundry_test/modules/commons/ModuleCalls.t.sol
@@ -103,7 +103,7 @@ contract ModuleCallsImp is ModuleCalls {
   }
 
   function signatureRecovery(bytes32, bytes calldata) public override view returns (
-    uint256, uint256, bytes32, bytes32
+    uint256, uint256, bytes32, bytes32, uint256
   ) {
   }
 

--- a/foundry_test/modules/commons/ModuleStaticAuth.t.sol
+++ b/foundry_test/modules/commons/ModuleStaticAuth.t.sol
@@ -54,7 +54,7 @@ contract ModuleStaticAuthTest is AdvTest {
   function _buildSignature(
     bytes32[] calldata _witnesses
   ) internal returns (bytes memory) {
-    return _buildSignatureWithPrefix(hex'0000', _witnesses);
+    return _buildSignatureWithPrefix(hex'000000000000', _witnesses);
   }
 
   function _buildSignatureWithPrefix(
@@ -99,8 +99,9 @@ contract ModuleStaticAuthTest is AdvTest {
     assertTrue(isValid);
     assertEq(resSubdigest, staticSubdigest);
 
-    bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff', _signatureWitnesses);
-    (isValid, resSubdigest) = imp.signatureValidation(_digest, belowThresholdSignature);
+    bytes memory belowThersholdSignature = _buildSignatureWithPrefix(hex'00ff703708f3', _signatureWitnesses);
+    (isValid, resSubdigest) = imp.signatureValidation(_digest, belowThersholdSignature);
+
     assertTrue(isValid);
     assertEq(resSubdigest, staticSubdigest);
   }
@@ -141,8 +142,9 @@ contract ModuleStaticAuthTest is AdvTest {
       assertTrue(isValid);
       assertEq(resSubdigest, staticSubdigest);
 
-      bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff', _signatureWitnesses);
+      bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff703708f3', _signatureWitnesses);
       (isValid, resSubdigest) = imp.signatureValidation(digest, belowThresholdSignature);
+
       assertTrue(isValid);
       assertEq(resSubdigest, staticSubdigest);
     }
@@ -197,7 +199,7 @@ contract ModuleStaticAuthTest is AdvTest {
     assertFalse(isValid);
     assertEq(resSubdigest, subDigest1);
 
-    bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff', _signatureWitnesses);
+    bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff703708f3', _signatureWitnesses);
     (isValid, resSubdigest) = imp.signatureValidation(_set1, belowThresholdSignature);
     assertFalse(isValid);
     assertEq(resSubdigest, subDigest1);

--- a/foundry_test/modules/commons/ModuleStaticAuth.t.sol
+++ b/foundry_test/modules/commons/ModuleStaticAuth.t.sol
@@ -99,8 +99,8 @@ contract ModuleStaticAuthTest is AdvTest {
     assertTrue(isValid);
     assertEq(resSubdigest, staticSubdigest);
 
-    bytes memory belowThersholdSignature = _buildSignatureWithPrefix(hex'00ff703708f3', _signatureWitnesses);
-    (isValid, resSubdigest) = imp.signatureValidation(_digest, belowThersholdSignature);
+    bytes memory belowThresholdSignature = _buildSignatureWithPrefix(hex'00ff703708f3', _signatureWitnesses);
+    (isValid, resSubdigest) = imp.signatureValidation(_digest, belowThresholdSignature);
 
     assertTrue(isValid);
     assertEq(resSubdigest, staticSubdigest);

--- a/foundry_test/modules/commons/submodules/auth/SequenceDynamicSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceDynamicSig.t.sol
@@ -8,11 +8,11 @@ import "foundry_test/base/AdvTest.sol";
 
 
 contract SequenceDynamicSigImp {
-  function recover(bytes32 _subDigest, bytes calldata _signature) external view returns (uint256, uint256, bytes32) {
+  function recover(bytes32 _subDigest, bytes calldata _signature) external view returns (uint256, uint256, bytes32, uint256) {
     return SequenceDynamicSig.recover(_subDigest, _signature);
   }
 
-  function recoverBase(bytes32 _subDigest, bytes calldata _signature) external view returns (uint256 threshold, uint256 weight, bytes32 imageHash) {
+  function recoverBase(bytes32 _subDigest, bytes calldata _signature) external view returns (uint256 threshold, uint256 weight, bytes32 imageHash, uint256) {
     return SequenceBaseSig.recover(_subDigest, _signature);
   }
 }
@@ -24,17 +24,17 @@ contract SequenceDynamicSigTest is AdvTest {
     lib = new SequenceDynamicSigImp();
   }
 
-  function test_recover_ignoreFirstByte(uint8 _first, bytes32 _subdigest, uint256 _pk, uint16 _threshold, uint8 _weight) external {
+  function test_recover_ignoreFirstByte(uint8 _first, bytes32 _subdigest, uint256 _pk, uint16 _threshold, uint32 _checkpoint, uint8 _weight) external {
     _pk = boundPk(_pk);
 
-    bytes memory signature = signAndPack(_pk, _subdigest, 1);
-    bytes memory encoded = abi.encodePacked(_threshold, uint8(0), _weight, signature);
+    bytes memory encoded = abi.encodePacked(_threshold, _checkpoint, uint8(0), _weight, signAndPack(_pk, _subdigest, 1));
 
-    (uint256 threshold1, uint256 weight1, bytes32 imageHash1) = lib.recover(_subdigest, abi.encodePacked(_first, encoded));
-    (uint256 threshold2, uint256 weight2, bytes32 imageHash2) = lib.recoverBase(_subdigest, encoded);
+    (uint256 threshold1, uint256 weight1, bytes32 imageHash1, uint256 checkpoint1) = lib.recover(_subdigest, abi.encodePacked(_first, encoded));
+    (uint256 threshold2, uint256 weight2, bytes32 imageHash2, uint256 checkpoint2) = lib.recoverBase(_subdigest, encoded);
 
     assertEq(threshold1, threshold2);
     assertEq(weight1, weight2);
     assertEq(imageHash1, imageHash2);
+    assertEq(checkpoint1, checkpoint2);
   }
 }

--- a/foundry_test/utils/LibBytes.t.sol
+++ b/foundry_test/utils/LibBytes.t.sol
@@ -20,6 +20,10 @@ contract LibBytesImp {
   function readFirstUint16(bytes calldata _data) external pure returns (uint16) {
     return _data.readFirstUint16();
   }
+
+  function readUint32(bytes calldata _data, uint256 _index) external pure returns (uint32) {
+    return _data.readUint32(_index);
+  }
 }
 
 contract LibBytesTest is AdvTest {
@@ -87,5 +91,11 @@ contract LibBytesTest is AdvTest {
     uint16 actual = lib.readFirstUint16(_data);
 
     assertEq(expected >> 240, actual);
+  }
+
+  function test_readUint32(bytes calldata _prefix, uint32 _data, bytes calldata _sufix) external {
+    bytes memory combined = abi.encodePacked(_prefix, _data, _sufix);
+    uint32 expected = lib.readUint32(combined, _prefix.length);
+    assertEq(expected, _data);
   }
 }

--- a/test/ChainedSignatures.spec.ts
+++ b/test/ChainedSignatures.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { ethers } from 'ethers'
 import { expectToBeRejected } from './utils'
 import { deploySequenceContext, SequenceContext } from './utils/contracts'
-import { getCheckpoint, SequenceWallet } from './utils/wallet'
+import { SequenceWallet } from './utils/wallet'
 
 contract('Chained signatures', (accounts: string[]) => {
   let context: SequenceContext
@@ -55,8 +55,8 @@ contract('Chained signatures', (accounts: string[]) => {
     let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
     let wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
 
-    const checkpoint1 = getCheckpoint()
-    const checkpoint2 = checkpoint1 + 1
+    const checkpoint1 = ethers.BigNumber.from(wallet.config.checkpoint).add(1)
+    const checkpoint2 = checkpoint1.add(1)
 
     wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint1 })
     wallet_c = wallet_c.useConfig({ ...wallet_c.config, checkpoint: checkpoint2 })
@@ -77,8 +77,8 @@ contract('Chained signatures', (accounts: string[]) => {
     let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
     let wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
 
-    const checkpoint1 = getCheckpoint()
-    const checkpoint2 = checkpoint1 - 1
+    const checkpoint1 = ethers.BigNumber.from(wallet.config.checkpoint).add(1)
+    const checkpoint2 = checkpoint1.sub(1)
 
     wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint1 })
     wallet_c = wallet_c.useConfig({ ...wallet_c.config, checkpoint: checkpoint2 })

--- a/test/ChainedSignatures.spec.ts
+++ b/test/ChainedSignatures.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { ethers } from 'ethers'
 import { expectToBeRejected } from './utils'
 import { deploySequenceContext, SequenceContext } from './utils/contracts'
-import { SequenceWallet } from './utils/wallet'
+import { getCheckpoint, SequenceWallet } from './utils/wallet'
 
 contract('Chained signatures', (accounts: string[]) => {
   let context: SequenceContext
@@ -20,10 +20,10 @@ contract('Chained signatures', (accounts: string[]) => {
     typehash = await wallet.mainModule.SET_IMAGEHASH_TYPEHASH() 
   })
 
-  const chain = (top: string, ...rest: { sig: string, checkpoint: ethers.BigNumberish }[]) => {
+  const chain = (top: string, ...rest: { sig: string }[]) => {
     const encodedRest = ethers.utils.solidityPack(
-      rest.map(() => ['uint64', 'uint24', 'bytes']).flat(),
-      rest.map((r) => [r.checkpoint, ethers.utils.arrayify(r.sig).length, r.sig]).flat()
+      rest.map(() => ['uint24', 'bytes']).flat(),
+      rest.map((r) => [ethers.utils.arrayify(r.sig).length, r.sig]).flat()
     )
 
     return ethers.utils.solidityPack(
@@ -32,60 +32,65 @@ contract('Chained signatures', (accounts: string[]) => {
     )
   }
 
-  const hashSetImagehash = (imagehash: string, checkpoint: ethers.BigNumberish) => {
+  const hashSetImagehash = (imagehash: string) => {
     return ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-      ['bytes32', 'bytes32', 'uint256'],
-      [typehash, imagehash, checkpoint]
+      ['bytes32', 'bytes32'],
+      [typehash, imagehash]
     ))
   }
 
   it("Should accept a single chained signature", async () => {
     const wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address })
-    const checkpoint = Math.floor(Date.now())
 
-    const hsih = hashSetImagehash(wallet_b.imageHash, checkpoint)
+    const hsih = hashSetImagehash(wallet_b.imageHash)
 
     const sig = await wallet.signDigest(hsih)
     const topsig = await wallet_b.signTransactions([{}])
-    const bundled = chain(topsig, { sig: sig, checkpoint })
+    const bundled = chain(topsig, { sig: sig })
 
     await wallet_b.relayTransactions([{}], bundled)
   })
 
   it("Should accept two chained signatures", async () => {
-    const wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
-    const wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
+    let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
+    let wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
 
-    const checkpoint1 = Math.floor(Date.now())
+    const checkpoint1 = getCheckpoint()
     const checkpoint2 = checkpoint1 + 1
 
-    const hsih1 = hashSetImagehash(wallet_b.imageHash, checkpoint1)
-    const hsih2 = hashSetImagehash(wallet_c.imageHash, checkpoint2)
+    wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint1 })
+    wallet_c = wallet_c.useConfig({ ...wallet_c.config, checkpoint: checkpoint2 })
+
+    const hsih1 = hashSetImagehash(wallet_b.imageHash)
+    const hsih2 = hashSetImagehash(wallet_c.imageHash)
 
     const sig1 = await wallet.signDigest(hsih1)
     const sig2 = await wallet_b.signDigest(hsih2)
 
     const topsig = await wallet_c.signTransactions([{}])
-    const bundled = chain(topsig, { sig: sig2, checkpoint: checkpoint2 }, { sig: sig1, checkpoint: checkpoint1 })
+    const bundled = chain(topsig, { sig: sig2 }, { sig: sig1 })
 
     await wallet_c.relayTransactions([{}], bundled)
   })
 
   it("Should reject chained signatures if checkpoint is wrongly ordered", async () => {
-    const wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
-    const wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
+    let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address, signing: 2, iddle: 1 })
+    let wallet_c = SequenceWallet.basicWallet(context, { address: wallet_b.address, signing: 3, iddle: 7 })
 
-    const checkpoint1 = Math.floor(Date.now())
+    const checkpoint1 = getCheckpoint()
     const checkpoint2 = checkpoint1 - 1
 
-    const hsih1 = hashSetImagehash(wallet_b.imageHash, checkpoint1)
-    const hsih2 = hashSetImagehash(wallet_c.imageHash, checkpoint2)
+    wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint1 })
+    wallet_c = wallet_c.useConfig({ ...wallet_c.config, checkpoint: checkpoint2 })
+
+    const hsih1 = hashSetImagehash(wallet_b.imageHash)
+    const hsih2 = hashSetImagehash(wallet_c.imageHash)
 
     const sig1 = await wallet.signDigest(hsih1)
     const sig2 = await wallet_b.signDigest(hsih2)
 
     const topsig = await wallet_c.signTransactions([{}])
-    const bundled = chain(topsig, { sig: sig2, checkpoint: checkpoint2 }, { sig: sig1, checkpoint: checkpoint1 })
+    const bundled = chain(topsig, { sig: sig2 }, { sig: sig1 })
 
     const tx = wallet_c.relayTransactions([{}], bundled)
     await expectToBeRejected(tx, `WrongChainedCheckpointOrder(${checkpoint1}, ${checkpoint2})`)
@@ -101,23 +106,31 @@ contract('Chained signatures', (accounts: string[]) => {
     await wallet.relayTransactions([{}], chain(chain(sig)))
   })
 
-  it("Should reject signature if current checkpoint is below signed checkpoints", async () => {
-    const wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address })
+  it("Should reject signature if current checkpoint is equal to signed checkpoint", async () => {
+    let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address })
 
-    const checkpoint = Math.floor(Date.now())
+    const checkpoint = ethers.BigNumber.from(wallet.config.checkpoint)
+    wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint })
 
-    await wallet.sendTransactions([{
-      target: wallet.address,
-      data: wallet.mainModule.interface.encodeFunctionData(
-        'setLastAuthCheckpoint', [checkpoint]
-      )
-    }])
-
-    const hsih = hashSetImagehash(wallet_b.imageHash, checkpoint)
+    const hsih = hashSetImagehash(wallet_b.imageHash)
     const sig = await wallet.signDigest(hsih)
     const topsig = await wallet_b.signTransactions([{}])
-    const bundled = chain(topsig, { sig: sig, checkpoint })
+    const bundled = chain(topsig, { sig: sig })
 
-    await expectToBeRejected(wallet_b.relayTransactions([{}], bundled), `WrongFinalCheckpoint(${checkpoint}, ${checkpoint})`)
+    await expectToBeRejected(wallet_b.relayTransactions([{}], bundled), `WrongChainedCheckpointOrder(${checkpoint}, ${checkpoint})`)
+  })
+
+  it("Should reject signature if current checkpoint is above to signed checkpoint", async () => {
+    let wallet_b = SequenceWallet.basicWallet(context, { address: wallet.address })
+
+    const checkpoint = ethers.BigNumber.from(wallet.config.checkpoint).sub(1)
+    wallet_b = wallet_b.useConfig({ ...wallet_b.config, checkpoint: checkpoint })
+
+    const hsih = hashSetImagehash(wallet_b.imageHash)
+    const sig = await wallet.signDigest(hsih)
+    const topsig = await wallet_b.signTransactions([{}])
+    const bundled = chain(topsig, { sig: sig })
+
+    await expectToBeRejected(wallet_b.relayTransactions([{}], bundled), `WrongChainedCheckpointOrder(${wallet.config.checkpoint}, ${checkpoint})`)
   })
 })

--- a/test/LibBytes.spec.ts
+++ b/test/LibBytes.spec.ts
@@ -69,6 +69,31 @@ contract('LibBytes', () => {
     })
   })
 
+  describe('readUint32', () => {
+    it('Should read uint32 at index zero', async () => {
+      const res = await libBytes.readUint32('0x837fc8a10d', 0)
+      expect(res).to.equal(2206189729)
+    })
+    it('Should read uint32 at given index', async () => {
+      const res = await libBytes.readUint32('0x5a9c2a992a8c22199af0', 3)
+      expect(res).to.equal(2569702434)
+    })
+    it('Should read uint32 at last index', async () => {
+      const res = await libBytes.readUint32('0x029183af982299dfa001', 6)
+      expect(res).to.equal(2581569537)
+    })
+    it('Should read zeros uint32 out of bounds', async () => {
+      const res1 = await libBytes.readUint32('0x2293', 1)
+      const res2 = await libBytes.readUint32('0x2193000000', 1)
+      expect(res1).to.equal(2466250752)
+      expect(res1).to.equal(res2)
+    })
+    it('Should read all zeros uint32 fully out of bounds', async () => {
+      const res = await libBytes.readUint32('0xff92a09f339922', 15)
+      expect(res).to.equal(0)
+    })
+  })
+
   describe('readUint16', () => {
     it('Should read uint16 at index zero', async () => {
       const res = await libBytesPointer.readUint16('0x5202', 0)

--- a/test/MainModule.spec.ts
+++ b/test/MainModule.spec.ts
@@ -440,7 +440,7 @@ contract('MainModule', (accounts: string[]) => {
     })
 
     it('Should reject signature with invalid flag', async () => {
-      const tx = wallet.relayTransactions([{}], '0x0001ff01')
+      const tx = wallet.relayTransactions([{}], '0x000193812833ff01')
       await expectToBeRejected(tx, 'InvalidSignatureFlag(255)')
     })
 
@@ -618,9 +618,9 @@ contract('MainModule', (accounts: string[]) => {
           }])
 
           expect(await wallet.mainModule.staticDigest(txDigest)).to.equal(expiration)
-          await wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x0000')
+          await wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x000000000000')
 
-          const relay2 = wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x0000')
+          const relay2 = wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x000000000000')
           await expectToBeRejected(relay2, `BadNonce(1, 0, 1)`)
         })
 
@@ -629,8 +629,8 @@ contract('MainModule', (accounts: string[]) => {
           const digest1 = ethers.utils.keccak256(message)
           const digest2 = ethers.utils.keccak256([])
 
-          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](digest1, '0x0000')).to.equal('0x00000000')
-          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](digest2, '0x0000')).to.equal('0x00000000')
+          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](digest1, '0x000000000000')).to.equal('0x00000000')
+          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](digest2, '0x000000000000')).to.equal('0x00000000')
 
           await wallet.sendTransactions([{
             target: wallet.address,
@@ -643,8 +643,8 @@ contract('MainModule', (accounts: string[]) => {
           expect(await wallet.mainModule.staticDigest(digest1)).to.equal(ethers.BigNumber.from(2).pow(256).sub(1))
           expect(await wallet.mainModule.staticDigest(digest2)).to.equal(ethers.BigNumber.from(2).pow(256).sub(1))
 
-          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](message, '0x0000')).to.equal('0x20c13b0b')
-          expect(await wallet.mainModule['isValidSignature(bytes32,bytes)'](digest2, '0x0000')).to.equal('0x1626ba7e')
+          expect(await wallet.mainModule['isValidSignature(bytes,bytes)'](message, '0x000000000000')).to.equal('0x20c13b0b')
+          expect(await wallet.mainModule['isValidSignature(bytes32,bytes)'](digest2, '0x000000000000')).to.equal('0x1626ba7e')
         })
 
         it('Should remove static digest', async () => {
@@ -697,9 +697,9 @@ contract('MainModule', (accounts: string[]) => {
           expect(await wallet.mainModule.staticDigest(txDigest2)).to.equal(ethers.BigNumber.from(2).pow(256).sub(1))
           expect(await wallet.mainModule.staticDigest(txDigest3)).to.equal(ethers.BigNumber.from(2).pow(256).sub(1))
 
-          await wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x0000')
-          await wallet.mainModule.execute(tx, encodeNonce(2, 0), '0x00ff')
-          await wallet.mainModule.execute(tx, encodeNonce(3, 0), '0x0000')
+          await wallet.mainModule.execute(tx, encodeNonce(1, 0), '0x000000000000')
+          await wallet.mainModule.execute(tx, encodeNonce(2, 0), '0x00ff00000001')
+          await wallet.mainModule.execute(tx, encodeNonce(3, 0), '0x0000ffffffff')
         })
       })
     })
@@ -725,7 +725,7 @@ contract('MainModule', (accounts: string[]) => {
 
           const prevLeaves = leavesOf(wallet.config.topology)
           const newMerkle = merkleTopology([subDigestsMerkle, ...prevLeaves])
-          const newConfig = { threshold: wallet.config.threshold, topology: newMerkle }
+          const newConfig = { threshold: wallet.config.threshold, topology: newMerkle, checkpoint: Math.floor(Date.now() / 1000) }
 
           await wallet.deploy()
           await wallet.updateImageHash(newConfig)
@@ -748,7 +748,7 @@ contract('MainModule', (accounts: string[]) => {
 
           const prevLeaves = leavesOf(wallet.config.topology)
           const newMerkle = merkleTopology([subDigestsMerkle, ...prevLeaves])
-          const newConfig = { threshold: wallet.config.threshold, topology: newMerkle }
+          const newConfig = { threshold: wallet.config.threshold, topology: newMerkle, checkpoint: Math.floor(Date.now() / 1000) }
 
           await wallet.deploy()
           await wallet.updateImageHash(newConfig)


### PR DESCRIPTION
- The `imageHash` tree now includes the checkpoint
- This reduces the cost of updating the wallet, since there is no need to update both `imageHash` and `checkpoint`
- Every signature must contain the `checkpoint` data in order to reconstruct the `imageHash`
- Checkpoint goes from `uint64` to `uint32`, if timestamp is used this should be enough until the year 2106, alternatively something like `timestamp / 10` can be used to further extend this range
