### PR TITLE
V2 nested configs

### DIFF
--- a/foundry_test/base/AdvTest.sol
+++ b/foundry_test/base/AdvTest.sol
@@ -114,6 +114,18 @@ contract AdvTest is Test {
     return boundDiff(_a, _arr);
   }
 
+  function boundDiff(uint256 _a, uint256 _b, uint256 _c, uint256 _d, uint256 _e, uint256 _f, uint256 _g, uint256 _h) internal pure returns (uint256) {
+    uint256[] memory _arr = new uint256[](7);
+    _arr[0] = _b;
+    _arr[1] = _c;
+    _arr[2] = _d;
+    _arr[3] = _e;
+    _arr[4] = _f;
+    _arr[5] = _g;
+    _arr[6] = _h;
+    return boundDiff(_a, _arr);
+  }
+
   function boundDiff(uint256 _a, uint256[] memory _b) internal pure returns (uint256) {
     unchecked {
       while (inSet(_a, _b)) {

--- a/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
@@ -95,6 +95,60 @@ contract SequenceBaseSigTest is AdvTest {
     assertEq(expected, actual);
   }
 
+  function test_leafForAddressAndWeight_fuzz(address _addr1, uint96 _weight1, address _addr2, uint96 _weight2) external {
+    bytes32 encoded1 = lib.leafForAddressAndWeight(_addr1, _weight1);
+    bytes32 encoded2 = lib.leafForAddressAndWeight(_addr2, _weight2);
+    assertEq(encoded1 == encoded2, _addr1 == _addr2 && _weight1 == _weight2);
+  }
+
+  function test_leafForHardcodedSubdigest_fuzz(bytes32 _subdigest1, bytes32 _subdigest2) external {
+    bytes32 encoded1 = SequenceBaseSig._leafForHardcodedSubdigest(_subdigest1);
+    bytes32 encoded2 = SequenceBaseSig._leafForHardcodedSubdigest(_subdigest2);
+    assertEq(encoded1 == encoded2, _subdigest1 == _subdigest2);
+  }
+
+  function test_leafForHardcodedSubdigest_fuzz_addr(address _addr, uint96 _weight, bytes32 _subdigest) external {
+    bytes32 encoded1 = SequenceBaseSig._leafForHardcodedSubdigest(_subdigest);
+    bytes32 encoded2 = SequenceBaseSig._leafForAddressAndWeight(_addr, _weight);
+    assertTrue(encoded1 != encoded2);
+  }
+
+  function test_leafForNested_fuzz(
+    bytes32 _node1,
+    uint256 _threshold1,
+    uint256 _weight1,
+    bytes32 _node2,
+    uint256 _threshold2,
+    uint256 _weight2
+  ) external {
+    bytes32 encoded1 = SequenceBaseSig._leafForNested(_node1, _threshold1, _weight1);
+    bytes32 encoded2 = SequenceBaseSig._leafForNested(_node2, _threshold2, _weight2);
+    assertEq(encoded1 == encoded2, _node1 == _node2 && _threshold1 == _threshold2 && _weight1 == _weight2);
+  }
+
+  function test_leafForNested_fuzz_addr(
+    address _addr,
+    uint96 _weight,
+    bytes32 _node,
+    uint256 _threshold,
+    uint256 _nodeWeight
+  ) external {
+    bytes32 encoded1 = SequenceBaseSig._leafForNested(_node, _threshold, _nodeWeight);
+    bytes32 encoded2 = SequenceBaseSig._leafForAddressAndWeight(_addr, _weight);
+    assertTrue(encoded1 != encoded2);
+  }
+
+  function test_leafForNested_fuzz_subdigest(
+    bytes32 _subdigest,
+    bytes32 _node,
+    uint256 _threshold,
+    uint256 _weight
+  ) external {
+    bytes32 encoded1 = SequenceBaseSig._leafForNested(_node, _threshold, _weight);
+    bytes32 encoded2 = SequenceBaseSig._leafForHardcodedSubdigest(_subdigest);
+    assertTrue(encoded1 != encoded2);
+  }
+
   function test_recoverBranch_Addresses(bytes32 _subdigest, bytes32 _seed, address[] calldata _addresses) external {
     bytes memory signature;
     bytes32 root;

--- a/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
@@ -11,8 +11,8 @@ contract SequenceBaseSigImp {
     return SequenceBaseSig.subdigest(_digest);
   }
 
-  function joinAddrAndWeight(address _addr, uint96 _weight) external pure returns (bytes32) {
-    return SequenceBaseSig._joinAddrAndWeight(_addr, _weight);
+  function leafForAddressAndWeight(address _addr, uint96 _weight) external pure returns (bytes32) {
+    return SequenceBaseSig._leafForAddressAndWeight(_addr, _weight);
   }
 
   function recoverBranch(bytes32 _digest, bytes calldata _signature) external view returns (uint256 weight, bytes32 root) {
@@ -33,6 +33,7 @@ contract SequenceBaseSigTest is AdvTest {
   uint8 private constant FLAG_NODE = 3;
   uint8 private constant FLAG_BRANCH = 4;
   uint8 private constant FLAG_SUBDIGEST = 5;
+  uint8 private constant FLAG_NESTED = 6;
 
   function setUp() public {
     lib = new SequenceBaseSigImp();
@@ -88,9 +89,9 @@ contract SequenceBaseSigTest is AdvTest {
     assertTrue(subdigest1 != subdigest2 || _addr1 == _addr2);
   }
 
-  function test_joinAddrAndWeight(address _addr, uint96 _weight) external {
+  function test_leafForAddressAndWeight(address _addr, uint96 _weight) external {
     bytes32 expected = abi.decode(abi.encodePacked(_weight, _addr), (bytes32));
-    bytes32 actual = lib.joinAddrAndWeight(_addr, _weight);
+    bytes32 actual = lib.leafForAddressAndWeight(_addr, _weight);
     assertEq(expected, actual);
   }
 
@@ -103,7 +104,7 @@ contract SequenceBaseSigTest is AdvTest {
       uint8 randomWeight = uint8(bound(uint256(keccak256(abi.encode(_addresses[i], i, _seed))), 0, type(uint8).max));
 
       signature = abi.encodePacked(signature, FLAG_ADDRESS, randomWeight, _addresses[i]);
-      bytes32 node = lib.joinAddrAndWeight(_addresses[i], randomWeight);
+      bytes32 node = lib.leafForAddressAndWeight(_addresses[i], randomWeight);
       root = root != bytes32(0) ? keccak256(abi.encodePacked(root, node)) : node;
     }
 
@@ -156,7 +157,7 @@ contract SequenceBaseSigTest is AdvTest {
         }
       }
 
-      bytes32 node = lib.joinAddrAndWeight(addr, randomWeight);
+      bytes32 node = lib.leafForAddressAndWeight(addr, randomWeight);
       root = root != bytes32(0) ? keccak256(abi.encodePacked(root, node)) : node;
     }
 
@@ -200,7 +201,7 @@ contract SequenceBaseSigTest is AdvTest {
         }
       }
 
-      bytes32 node = lib.joinAddrAndWeight(addr, randomWeight);
+      bytes32 node = lib.leafForAddressAndWeight(addr, randomWeight);
       // Hash in reverse order requires branching, root/node -> node/root
       root = root != bytes32(0) ? keccak256(abi.encodePacked(node, root)) : node;
     }
@@ -221,7 +222,7 @@ contract SequenceBaseSigTest is AdvTest {
   }
 
   function test_recoverBranch_Fail_InvalidFlag(uint8 _flag, bytes23 _hash, bytes calldata _sufix) external {
-    _flag = uint8(boundDiff(_flag, FLAG_SIGNATURE, FLAG_ADDRESS, FLAG_DYNAMIC_SIGNATURE, FLAG_NODE, FLAG_BRANCH, FLAG_SUBDIGEST));
+    _flag = uint8(boundDiff(_flag, FLAG_SIGNATURE, FLAG_ADDRESS, FLAG_DYNAMIC_SIGNATURE, FLAG_NODE, FLAG_BRANCH, FLAG_SUBDIGEST, FLAG_NESTED));
 
     vm.expectRevert(abi.encodeWithSignature('InvalidSignatureFlag(uint256)', _flag));
     lib.recoverBranch(_hash, abi.encodePacked(_flag, _sufix));

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.2",
     "scrypt": "github:barrysteyn/node-scrypt#fb60a8d3c158fe115a624b5ffa7480f3a24b03fb",
     "solhint": "^3.3.7",
-    "solidity-coverage": "0.8.0-beta.1",
+    "solidity-coverage": "0.8.2",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",
     "typescript": "^4.7.4",

--- a/test/MainModule.spec.ts
+++ b/test/MainModule.spec.ts
@@ -5,7 +5,7 @@ import { bytes32toAddress, CHAIN_ID, expect, expectToBeRejected, randomHex } fro
 
 import { CallReceiverMock, ContractType, deploySequenceContext, ModuleMock, SequenceContext, DelegateCallMock, HookMock, HookCallerMock, GasBurnerMock } from './utils/contracts'
 import { Imposter } from './utils/imposter'
-import { applyTxDefaults, computeStorageKey, digestOf, encodeNonce, leavesOf, merkleTopology, SignatureType, subdigestOf } from './utils/sequence'
+import { applyTxDefaults, computeStorageKey, digestOf, encodeNonce, leavesOf, legacyTopology, merkleTopology, optimize2SignersTopology, printTopology, SignatureType, SimplifiedWalletConfig, subdigestOf, toSimplifiedConfig, WalletConfig } from './utils/sequence'
 import { SequenceWallet, StaticSigner } from './utils/wallet'
 
 contract('MainModule', (accounts: string[]) => {
@@ -764,6 +764,109 @@ contract('MainModule', (accounts: string[]) => {
           }
         })
       })
+    })
+  })
+
+  describe('Nested configurations', async () => {
+    it('Should use nested configuration as a regular branch', async () => {
+      const nested = SequenceWallet.basicWallet(context, { signing: 1, idle: 11 })
+      const simplifiedConfig = {
+        threshold: 1,
+        checkpoint: 2,
+        signers: [{
+          address: ethers.Wallet.createRandom().address,
+          weight: 1
+        }, {
+          ...toSimplifiedConfig(nested.config),
+          weight: 1
+        }]
+      }
+
+      const config = {
+        ...simplifiedConfig,
+        topology: legacyTopology(simplifiedConfig)
+      }
+
+      const wallet = new SequenceWallet({ context, config, signers: nested.signers })
+      await wallet.deploy()
+
+      await wallet.sendTransactions([])
+    })
+    it('Should use nested configuration with independent weight and threshold', async () => {
+      const nested = SequenceWallet.basicWallet(context, { signing: 2, idle: 11 })
+      const simplifiedConfig = {
+        threshold: 5,
+        checkpoint: 2,
+        signers: [{
+          ...toSimplifiedConfig(nested.config),
+          weight: 5
+        }, {
+          address: ethers.Wallet.createRandom().address,
+          weight: 1
+        }]
+      }
+
+      const config = {
+        ...simplifiedConfig,
+        topology: merkleTopology(simplifiedConfig)
+      }
+
+      const wallet = new SequenceWallet({ context, config, signers: nested.signers })
+      await wallet.deploy()
+
+      await wallet.sendTransactions([])
+    })
+    it('Should reject nested configuration if not enough internal signing power', async () => {
+      const nested = SequenceWallet.basicWallet(context, { signing: 2, idle: 11 })
+
+      const simplifiedConfig = {
+        threshold: 1,
+        checkpoint: 2,
+        signers: [{
+          ...toSimplifiedConfig(nested.config),
+          weight: 5
+        }, {
+          address: ethers.Wallet.createRandom().address,
+          weight: 1
+        }]
+      }
+
+      const config = {
+        ...simplifiedConfig,
+        topology: merkleTopology(simplifiedConfig)
+      }
+
+      const wallet = new SequenceWallet({ context, config, signers: [nested.signers[0]] })
+      await wallet.deploy()
+
+      const tx = wallet.sendTransactions([])
+      await expectToBeRejected(tx, 'InvalidSignature')
+    })
+    it('Should limit nested signing power', async () => {
+      const nested = SequenceWallet.basicWallet(context, { signing: 10 })
+
+      const simplifiedConfig = {
+        threshold: 2,
+        checkpoint: 2,
+        signers: [{
+          ...toSimplifiedConfig(nested.config),
+          weight: 1
+        }, {
+          address: ethers.Wallet.createRandom().address,
+          weight: 1
+        }]
+      }
+
+      const config = {
+        ...simplifiedConfig,
+        topology: merkleTopology(simplifiedConfig)
+      }
+
+      const wallet = new SequenceWallet({ context, config, signers: nested.signers })
+      await wallet.deploy()
+
+      const tx = wallet.sendTransactions([])
+      await expectToBeRejected(tx, 'InvalidSignature')
     })
   })
 

--- a/test/utils/sequence.ts
+++ b/test/utils/sequence.ts
@@ -18,7 +18,13 @@ export type SubdigestLeaf = {
   subdigest: string
 }
 
-export type ConfigLeaf = SubdigestLeaf | SignerLeaf
+export type NestedLeaf = {
+  tree: ConfigTopology,
+  internalThreshold: BigNumberish,
+  externalWeight: BigNumberish,
+}
+
+export type ConfigLeaf = SubdigestLeaf | SignerLeaf | NestedLeaf
 
 export type ImageHashNode = {
   left: ConfigTopology,
@@ -57,7 +63,8 @@ export enum SignaturePartType {
   Dynamic = 2,
   Node = 3,
   Branch = 4,
-  Subdigest = 5
+  Subdigest = 5,
+  Nested = 6
 }
 
 export type SignaturePart = {
@@ -109,6 +116,10 @@ export function isSignerLeaf(node: ConfigTopology): node is SignerLeaf {
 
 export function isSubdigestLeaf(node: ConfigTopology): node is SubdigestLeaf {
   return isConfigLeaf(node) && 'subdigest' in node
+}
+
+export function isNestedLeaf(node: ConfigTopology): node is NestedLeaf {
+  return isConfigLeaf(node) && 'tree' in node
 }
 
 export function legacyTopology(config: SimplifiedWalletConfig): ConfigTopology {
@@ -223,6 +234,13 @@ export function hashNode(node: ConfigTopology): string {
     )
   }
 
+  if (isNestedLeaf(node)) {
+    return ethers.utils.solidityKeccak256(
+      ['string', 'bytes32', 'uint256', 'uint256'],
+      ['Sequence nested config:\n', hashNode(node.tree), node.internalThreshold, node.externalWeight]
+    )
+  }
+
   return ethers.utils.solidityKeccak256(
     ['bytes32', 'bytes32'],
     [hashNode(node.left), hashNode(node.right)]
@@ -260,6 +278,17 @@ export function printTopology(topology: ConfigTopology, threshold?: ethers.BigNu
 
   if (isSubdigestLeaf(topology)) {
     return [`subdigest: ${topology.subdigest}`]
+  }
+
+  if (isNestedLeaf(topology)) {
+    const result: string[] = [`internalThreshold: ${topology.internalThreshold} - externalWeight: ${topology.externalWeight}`]
+    const signers = printTopology(topology.tree, undefined, inverse)
+    for (let i = 0; i < signers.length; i++) {
+      const prefix = i === 0 ? '└─ ' : '  '
+      result.push(`${prefix}${signers[i]}`)
+    }
+
+    return result
   }
 
   const root = hashNode(topology)
@@ -387,7 +416,8 @@ type DecodedSignatureMember = {
   weight?: ethers.BigNumberish,
   address?: string,
   type: SignaturePartType,
-  value?: string
+  value?: string,
+  innerThreshold?: ethers.BigNumberish,
 }
 
 export class SignatureConstructor {
@@ -463,6 +493,10 @@ export class SignatureConstructor {
     this.members.push({ type: SignaturePartType.Subdigest, value: subdigest})
   }
 
+  appendNested(branch: string, weight: ethers.BigNumberish, innerThreshold: ethers.BigNumberish) {
+    this.members.push({ type: SignaturePartType.Nested, value: branch, innerThreshold, weight })
+  }
+
   encode(): string {
     let result = '0x'
 
@@ -512,6 +546,14 @@ export class SignatureConstructor {
           )
           break
 
+        case SignaturePartType.Nested:
+          const nestedBranch = ethers.utils.arrayify(member.value ?? [])
+          result = ethers.utils.solidityPack(
+            ['bytes', 'uint8', 'uint8', 'uint16', 'uint24', 'bytes'],
+            [result, SignaturePartType.Nested, member.weight, member.innerThreshold, nestedBranch.length, nestedBranch]
+          )
+          break
+
         default:
           throw new Error(`Unknown signature part type: ${member.type}`)
       }
@@ -541,7 +583,7 @@ export function encodeSigners(
 
   const constructor = new SignatureConstructor(options?.disableTrim)
   for (const node of slice) {
-    if (!isConfigLeaf(node)) {
+    if (!isConfigLeaf(node) || isNestedLeaf(node)) {
       // If the node opens up to another branch
       // we recurse the encoding, and if the result has any weight
       // we have to embed the whole branch, otherwise we just add the node
@@ -549,8 +591,18 @@ export function encodeSigners(
       if (nested.weight.isZero() && !options?.disableTrim) {
         constructor.appendNode(hashNode(node))
       } else {
-        constructor.appendBranch(nested.encoded)
-        weight = weight.add(nested.weight)
+        if (isNestedLeaf(node)) {
+          // Nested configs only have weight if the inner threshold is met
+          // and the weight is always the external weight
+          if (nested.weight.gte(node.internalThreshold)) {
+            weight = weight.add(node.externalWeight)
+          }
+
+          constructor.appendNested(nested.encoded, node.externalWeight, node.internalThreshold)
+        } else {
+          constructor.appendBranch(nested.encoded)
+          weight = weight.add(nested.weight)
+        }
       }
     } else {
       if (isSignerLeaf(node)) {

--- a/test/utils/sequence.ts
+++ b/test/utils/sequence.ts
@@ -39,14 +39,20 @@ export type WalletConfig = {
   topology: ConfigTopology
 }
 
+export type SimplifiedNestedWalletConfig = {
+  threshold: ethers.BigNumberish,
+  weight: ethers.BigNumberish,
+  signers: SimplifiedConfigMember[]
+}
+
 export type SimplifiedWalletConfig = {
   threshold: BigNumberish,
   checkpoint: BigNumberish,
-  signers: {
-    weight: BigNumberish
-    address: string
-  }[]
+  signers: SimplifiedConfigMember[]
 }
+
+
+export type SimplifiedConfigMember = SignerLeaf | SimplifiedNestedWalletConfig
 
 export type Transaction = {
   delegateCall: boolean;
@@ -110,8 +116,8 @@ export function isConfigLeaf(node: ConfigTopology): node is ConfigLeaf {
   return !('left' in node || 'right' in node)
 }
 
-export function isSignerLeaf(node: ConfigTopology): node is SignerLeaf {
-  return isConfigLeaf(node) && 'weight' in node
+export function isSignerLeaf(node: any): node is SignerLeaf {
+  return isConfigLeaf(node) && 'weight' in node && 'address' in node
 }
 
 export function isSubdigestLeaf(node: ConfigTopology): node is SubdigestLeaf {
@@ -122,43 +128,34 @@ export function isNestedLeaf(node: ConfigTopology): node is NestedLeaf {
   return isConfigLeaf(node) && 'tree' in node
 }
 
-export function legacyTopology(config: SimplifiedWalletConfig): ConfigTopology {
-  if (config.signers.length === 1) {
+export function legacyTopology(leavesOrConfig: SimplifiedWalletConfig | ConfigTopology[]): ConfigTopology {
+  if (!Array.isArray(leavesOrConfig)) {
+    return legacyTopology(toTopology(leavesOrConfig))
+  }
+
+  return leavesOrConfig.reduce((acc, leaf) => {
     return {
-      address: config.signers[0].address,
-      weight: config.signers[0].weight
+      left: acc,
+      right: leaf
     }
-  }
-
-  let root: ImageHashNode = {
-    left: {
-      address: config.signers[0].address,
-      weight: config.signers[0].weight
-    },
-    right: {
-      address: config.signers[1].address,
-      weight: config.signers[1].weight
-    }
-  }
-
-  for (let i = 2; i < config.signers.length; i++) {
-    root = {
-      left: root,
-      right: {
-        address: config.signers[i].address,
-        weight: config.signers[i].weight
-      }
-    }
-  }
-
-  return root
+  })
 }
 
-export function toTopology(config: SimplifiedWalletConfig): ConfigTopology[] {
-  return config.signers.map(s => ({
-    address: s.address,
-    weight: s.weight
-  })) as ConfigTopology[]
+export function toTopology(config: SimplifiedWalletConfig | SimplifiedNestedWalletConfig): ConfigTopology[] {
+  return config.signers.map(s => {
+    if (isSignerLeaf(s)) {
+      return {
+        address: s.address,
+        weight: s.weight
+      }
+    }
+
+    return {
+      tree: merkleTopology(toTopology(s)),
+      internalThreshold: s.threshold,
+      externalWeight: s.weight
+    }
+  })
 }
 
 export function merkleTopology(leavesOrConfig: SimplifiedWalletConfig | ConfigTopology[]): ConfigTopology {
@@ -583,7 +580,7 @@ export function encodeSigners(
 
   const constructor = new SignatureConstructor(options?.disableTrim)
   for (const node of slice) {
-    if (!isConfigLeaf(node) || isNestedLeaf(node)) {
+    if (!isConfigLeaf(node)) {
       // If the node opens up to another branch
       // we recurse the encoding, and if the result has any weight
       // we have to embed the whole branch, otherwise we just add the node
@@ -591,18 +588,8 @@ export function encodeSigners(
       if (nested.weight.isZero() && !options?.disableTrim) {
         constructor.appendNode(hashNode(node))
       } else {
-        if (isNestedLeaf(node)) {
-          // Nested configs only have weight if the inner threshold is met
-          // and the weight is always the external weight
-          if (nested.weight.gte(node.internalThreshold)) {
-            weight = weight.add(node.externalWeight)
-          }
-
-          constructor.appendNested(nested.encoded, node.externalWeight, node.internalThreshold)
-        } else {
-          constructor.appendBranch(nested.encoded)
-          weight = weight.add(nested.weight)
-        }
+        constructor.appendBranch(nested.encoded)
+        weight = weight.add(nested.weight)
       }
     } else {
       if (isSignerLeaf(node)) {
@@ -613,6 +600,22 @@ export function encodeSigners(
         }
 
         constructor.appendPart(node.weight, part)
+      } else if (isNestedLeaf(node)) {
+        // If the node opens up to another branch
+        // we recurse the encoding, and if the result has any weight
+        // we have to embed the whole branch, otherwise we just add the node
+        const nested = encodeSigners(node.tree, parts, subdigests, options)
+        if (nested.weight.isZero() && !options?.disableTrim) {
+          constructor.appendNode(hashNode(node))
+        } else {
+          // Nested configs only have weight if the inner threshold is met
+          // and the weight is always the external weight
+          if (nested.weight.gte(node.internalThreshold)) {
+            weight = weight.add(node.externalWeight)
+          }
+
+          constructor.appendNested(nested.encoded, node.externalWeight, node.internalThreshold)
+        }
       } else {
         // If the node is a subdigest add the node (unless it's an static subdigest signature)
         if (subdigests.includes(node.subdigest)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,22 +992,13 @@
   resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.1.0.tgz#5e9fed79e6cda624c926d314b280a576f8b22a36"
   integrity sha512-RbUfp5VreNhsa2Q4YbBjz18rOQI909pG32bghl1hulO7IpvcqTS+C3Ge5cNbiWQ1WGzy1wIeKLW0tmQtHFB7qg==
 
-"@truffle/interface-adapter@^0.5.16", "@truffle/interface-adapter@^0.5.17":
+"@truffle/interface-adapter@^0.5.16":
   version "0.5.17"
   resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.5.17.tgz#34e7e28930f6aa4c722f1b2ede127d379f891e70"
   integrity sha512-2MJ+YLAL4y2QqlWc90NKizBLpavcETTzV8EpYkYJgAM326xKrAt+N3wx3f3tgRPSsbdtiEVKf1JRXHmDYQ+xIg==
   dependencies:
     bn.js "^5.1.3"
     ethers "^4.0.32"
-    web3 "1.5.3"
-
-"@truffle/provider@^0.2.24":
-  version "0.2.55"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.55.tgz#044c7555fcae05128565096571bce44895aa9c5c"
-  integrity sha512-Tjs2cZsmRnzgBtFNXwO8cc1W7jIv0UaaLt3fOzks7rSUETo7M11GJ4U+uoCHSntrIW7E6sYS3KecOpzqJPw3Hg==
-  dependencies:
-    "@truffle/error" "^0.1.0"
-    "@truffle/interface-adapter" "^0.5.17"
     web3 "1.5.3"
 
 "@trufflesuite/chromafi@^3.0.0":
@@ -5270,7 +5261,7 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-ganache-cli@6.12.2, ganache-cli@^6.11.0:
+ganache-cli@6.12.2:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.2.tgz#c0920f7db0d4ac062ffe2375cb004089806f627a"
   integrity sha512-bnmwnJDBDsOWBUP8E/BExWf85TsdDEFelQSzihSJm9VChVO1SHp94YXLP5BlA4j/OTxp0wR4R1Tje9OHOuAJVw==
@@ -9460,20 +9451,18 @@ solhint@^3.3.7:
   optionalDependencies:
     prettier "^1.14.3"
 
-solidity-coverage@0.8.0-beta.1:
-  version "0.8.0-beta.1"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.0-beta.1.tgz#f9956037d3d98ad15eb2664ae55b8291ebb5a409"
-  integrity sha512-OsdzW0K0v7osWyDUPP82wNehKOsZ4o+2yfVnjtI9PX5tmEbBzNHxKmmef+pRxy9kkqhJRV8AcdM7G0qu7W8gXA==
+solidity-coverage@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.2.tgz#bc39604ab7ce0a3fa7767b126b44191830c07813"
+  integrity sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==
   dependencies:
     "@ethersproject/abi" "^5.0.9"
     "@solidity-parser/parser" "^0.14.1"
-    "@truffle/provider" "^0.2.24"
     chalk "^2.4.2"
     death "^1.1.0"
     detect-port "^1.3.0"
     difflib "^0.2.4"
     fs-extra "^8.1.0"
-    ganache-cli "^6.11.0"
     ghost-testrpc "^0.0.2"
     global-modules "^2.0.0"
     globby "^10.0.1"
@@ -9486,7 +9475,7 @@ solidity-coverage@0.8.0-beta.1:
     sc-istanbul "^0.4.5"
     semver "^7.3.4"
     shelljs "^0.8.3"
-    web3-utils "^1.3.0"
+    web3-utils "^1.3.6"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -11259,12 +11248,25 @@ web3-utils@1.5.3:
     randombytes "^2.1.0"
     utf8 "3.0.0"
 
-web3-utils@1.7.3, web3-utils@^1.0.0-beta.31, web3-utils@^1.3.0:
+web3-utils@1.7.3, web3-utils@^1.0.0-beta.31:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.7.3.tgz#b214d05f124530d8694ad364509ac454d05f207c"
   integrity sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==
   dependencies:
     bn.js "^4.11.9"
+    ethereum-bloom-filters "^1.0.6"
+    ethereumjs-util "^7.1.0"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
+web3-utils@^1.3.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.8.0.tgz#0a506f8c6af9a2ad6ba79689892662769534fc03"
+  integrity sha512-7nUIl7UWpLVka2f09CMbKOSEvorvHnaugIabU4mj7zfMvm0tSByLcEu3eyV9qgS11qxxLuOkzBIwCstTflhmpQ==
+  dependencies:
+    bn.js "^5.2.1"
     ethereum-bloom-filters "^1.0.6"
     ethereumjs-util "^7.1.0"
     ethjs-unit "0.1.6"


### PR DESCRIPTION
Depends on https://github.com/0xsequence/wallet-contracts/pull/154

## Adds support for nested wallet configs

Nested wallet configs have an independent threshold and an independent weight, if the signatures inside the nested configuration reach the threshold then the defined weight is applied to the parent signature.

### Uses

- Limiting signing power of a combined set of signers
- Building wallet configurations above the limits imposed by the weight size (8 bits)
- Building "all or nothing" groups of signers
