### PR TITLE
Test stability

### DIFF
--- a/foundry_test/base/AdvTest.sol
+++ b/foundry_test/base/AdvTest.sol
@@ -5,17 +5,17 @@ import "forge-std/Test.sol";
 
 
 contract AdvTest is Test {
-  function signAndPack(uint256 _pk, bytes32 _hash) internal returns (bytes memory) {
+  function signAndPack(uint256 _pk, bytes32 _hash) internal pure returns (bytes memory) {
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_pk, _hash);
     return abi.encodePacked(r, s, v);
   }
 
-  function signAndPack(uint256 _pk, bytes32 _hash, uint8 _sufix) internal returns (bytes memory) {
+  function signAndPack(uint256 _pk, bytes32 _hash, uint8 _sufix) internal pure returns (bytes memory) {
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_pk, _hash);
     return abi.encodePacked(r, s, v, _sufix);
   }
 
-  function mayBoundArr(uint256 _size) internal returns (uint256) {
+  function mayBoundArr(uint256 _size) internal view returns (uint256) {
     try vm.envUint('MAX_ARRAY_LEN') returns (uint256 b) {
       return b == 0 ? _size : bound(_size, 0, b);
     } catch {
@@ -28,24 +28,20 @@ contract AdvTest is Test {
     address vm = address(0x004e59b44847b379578588920ca78fbf26c0b4956c);
     address c3 = address(0x00000000000000000000636f6e736f6c652e6c6f67);
 
-    _a = boundNoPrecompile(_a);
-    _a = boundDiff(_a, c2, vm, c3, address(this));
+    boundNoPrecompile(_a);
+    boundDiff(_a, c2, vm, c3, address(this));
 
     return _a;
   }
 
   function boundNoPrecompile(address _a) internal pure returns (address) {
-    if (uint160(_a) > 0 && uint160(_a) < 10) {
-      return address(10);
-    }
-
+    vm.assume(uint160(_a)> 10);
     return _a;
   }
 
   function boundDiff(address _a, address _b) internal pure returns (address) {
-    if (_a != _b) return _a;
-
-    return address(uint160(_b) == type(uint160).max ? 0 : uint160(_b) + 1);
+    vm.assume(_a != _b);
+    return _a;
   }
 
   function boundDiff(address _a, address _b, address _c) internal pure returns (address) {
@@ -73,30 +69,18 @@ contract AdvTest is Test {
   }
 
   function boundDiff(address _a, address[] memory _b) internal pure returns (address) {
-    unchecked {
-      while (inSet(_a, _b)) {
-        _a = address(uint160(_a) + 1);
-      }
-
-      return _a;
-    }
+    vm.assume(!inSet(_a, _b));
+    return _a;
   }
 
   function boundPk(uint256 _a) internal pure returns (uint256) {
-    if (_a > 0 && _a <= 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140) {
-      return _a;
-    }
-
-    uint256 mod = _a % 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140;
-    return 1 + mod;
+    vm.assume(_a > 0 && _a <= 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140);
+    return _a;
   }
 
   function boundDiff(uint256 _a, uint256 _b) internal pure returns (uint256) {
-    if (_a != _b) return _a;
-
-    unchecked {
-      return _a + 1;
-    }
+    vm.assume(_a != _b);
+    return _a;
   }
 
   function boundDiff(uint256 _a, uint256 _b, uint256 _c) internal pure returns (uint256) {
@@ -157,13 +141,8 @@ contract AdvTest is Test {
   }
 
   function boundDiff(uint256 _a, uint256[] memory _b) internal pure returns (uint256) {
-    unchecked {
-      while (inSet(_a, _b)) {
-        _a++;
-      }
-
-      return _a;
-    }
+    vm.assume(!inSet(_a, _b));
+    return _a;
   }
 
   function inSet(uint256 _a, uint256[] memory _b) internal pure returns (bool) {
@@ -188,6 +167,16 @@ contract AdvTest is Test {
 
       return false;
     }
+  }
+
+  function boundNoContract(address _a) internal view returns (address) {
+    vm.assume(_a.code.length == 0);
+    return _a;
+  }
+
+  function boundNoBalance(address _a) internal view returns (address) {
+    vm.assume(_a.balance == 0);
+    return _a;
   }
 
   function replicate(bytes memory _data) internal {

--- a/foundry_test/modules/commons/Implementation.t.sol
+++ b/foundry_test/modules/commons/Implementation.t.sol
@@ -29,7 +29,7 @@ contract NextImplementation is ImplementationImp {
 
 contract ImplementationTest is AdvTest {
   function test_setImplementation(address _imp, address _next) external {
-    _imp = boundNoSys(_imp);
+    boundNoContract(boundNoSys(_imp));
 
     vm.etch(_imp, address(new ImplementationImp()).code);
 
@@ -44,19 +44,19 @@ contract ImplementationTest is AdvTest {
   function test_setImplementation_matchWallet(bytes32 _salt, address _imp, address _imp2) external {
     Factory factory = new Factory();
 
-    _imp = boundNoSys(_imp);
-    _imp2 = boundNoSys(_imp2);
+    ImplementationImp imp = new ImplementationImp();
+    ImplementationImp imp2 = new NextImplementation();
 
-    _imp = boundDiff(_imp, address(factory));
-    _imp2 = boundDiff(_imp2, address(factory));
+    boundNoContract(boundDiff(boundNoSys(_imp), address(factory)));
+    boundNoContract(boundDiff(boundNoSys(_imp2), address(factory)));
 
-    vm.etch(_imp, address(new ImplementationImp()).code);
+    vm.etch(_imp, address(imp).code);
     address wallet = factory.deploy(_imp, _salt);
 
     assertEq(ImplementationImp(wallet).getImplementation(), _imp);
     assertEq(ImplementationImp(wallet).stub(), 1);
 
-    vm.etch(_imp2, address(new NextImplementation()).code);
+    vm.etch(_imp2, address(imp2).code);
 
     ImplementationImp(wallet).setImplementation(_imp2);
 

--- a/foundry_test/modules/commons/ModuleCalls.t.sol
+++ b/foundry_test/modules/commons/ModuleCalls.t.sol
@@ -148,7 +148,7 @@ contract ModuleCallsTest is AdvTest {
 
     for (uint256 i = 0; i < size; i++) {
       txs[i].data = _rtxs[i].data;
-      txs[i].target = boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory));
+      txs[i].target = boundNoBalance(boundNoContract(boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory))));
       txs[i].value = bound(_rtxs[i].value, 0, type(uint256).max - total);
 
       total += txs[i].value;
@@ -207,7 +207,7 @@ contract ModuleCallsTest is AdvTest {
         txs[i].revertOnError = _revertsOnErr;
         txs[i].delegateCall = _delegateCall;
       } else {
-        txs[i].target = boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory));
+        txs[i].target = boundNoBalance(boundNoContract(boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory))));
       }
 
       txs[i].data = _rtxs[i].data;
@@ -271,7 +271,7 @@ contract ModuleCallsTest is AdvTest {
 
     for (uint256 i = 0; i < size; i++) {
       txs[i].data = _rtxs[i].data;
-      txs[i].target = boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory));
+      txs[i].target = boundNoBalance(boundNoContract(boundDiff(boundNoSys(_rtxs[i].target), address(template), address(imp), address(factory))));
       txs[i].value = bound(_rtxs[i].value, 0, type(uint256).max - total);
 
       total += txs[i].value;

--- a/foundry_test/modules/commons/ModuleExtraAuth.t.sol
+++ b/foundry_test/modules/commons/ModuleExtraAuth.t.sol
@@ -157,7 +157,7 @@ contract ModuleExtraAuthTest is AdvTest {
     bytes32 _imageHash,
     uint256 _expiration
   ) external {
-    _caller = boundDiff(_caller, address(imp));
+    boundDiff(_caller, address(imp));
     vm.expectRevert(abi.encodeWithSignature('OnlySelfAuth(address,address)', _caller, address(imp)));
     vm.prank(_caller);
     imp.setExtraImageHash(_imageHash, _expiration);
@@ -167,7 +167,7 @@ contract ModuleExtraAuthTest is AdvTest {
     address _caller,
     bytes32[] calldata _clear
   ) external {
-    _caller = boundDiff(_caller, address(imp));
+    boundDiff(_caller, address(imp));
     vm.expectRevert(abi.encodeWithSignature('OnlySelfAuth(address,address)', _caller, address(imp)));
     vm.prank(_caller);
     imp.clearExtraImageHashes(_clear);

--- a/foundry_test/modules/commons/ModuleIPFS.t.sol
+++ b/foundry_test/modules/commons/ModuleIPFS.t.sol
@@ -43,7 +43,7 @@ contract ModuleIPFSTest is AdvTest {
   }
 
   function test_fail_updateIPFSRoot_notSelf(address _notSelf) external {
-    _notSelf = boundDiff(_notSelf, address(module));
+    boundDiff(_notSelf, address(module));
 
     vm.prank(address(_notSelf));
     vm.expectRevert(abi.encodeWithSignature('OnlySelfAuth(address,address)', _notSelf, address(module)));

--- a/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceBaseSig.t.sol
@@ -77,8 +77,8 @@ contract SequenceBaseSigTest is AdvTest {
   }
 
   function test_subdigest_Fuzz_Address(bytes32 _digest, address _addr1, address _addr2) external {
-    _addr1 = boundNoSys(_addr1);
-    _addr2 = boundNoSys(_addr2);
+    boundNoSys(_addr1);
+    boundNoSys(_addr2);
 
     vm.etch(_addr1, address(lib).code);
     vm.etch(_addr2, address(lib).code);
@@ -189,7 +189,7 @@ contract SequenceBaseSigTest is AdvTest {
 
     uint256 size = mayBoundArr(_pks.length);
     for (uint256 i = 0; i < size; i++) {
-      _pks[i] = boundPk(_pks[i]);
+      boundPk(_pks[i]);
 
       uint8 randomWeight = uint8(bound(uint256(keccak256(abi.encode(_pks[i], i, _seed))), 0, type(uint8).max));
       address addr = vm.addr(_pks[i]);
@@ -233,7 +233,7 @@ contract SequenceBaseSigTest is AdvTest {
         signature = abi.encodePacked(FLAG_BRANCH, uint24(signature.length), signature);
       }
 
-      _pks[i] = boundPk(_pks[i]);
+      boundPk(_pks[i]);
 
       uint8 randomWeight = uint8(bound(uint256(keccak256(abi.encode(_pks[i], i, _seed))), 0, type(uint8).max));
       address addr = vm.addr(_pks[i]);
@@ -276,14 +276,14 @@ contract SequenceBaseSigTest is AdvTest {
   }
 
   function test_recoverBranch_Fail_InvalidFlag(uint8 _flag, bytes23 _hash, bytes calldata _sufix) external {
-    _flag = uint8(boundDiff(_flag, FLAG_SIGNATURE, FLAG_ADDRESS, FLAG_DYNAMIC_SIGNATURE, FLAG_NODE, FLAG_BRANCH, FLAG_SUBDIGEST, FLAG_NESTED));
+    uint8(boundDiff(_flag, FLAG_SIGNATURE, FLAG_ADDRESS, FLAG_DYNAMIC_SIGNATURE, FLAG_NODE, FLAG_BRANCH, FLAG_SUBDIGEST, FLAG_NESTED));
 
     vm.expectRevert(abi.encodeWithSignature('InvalidSignatureFlag(uint256)', _flag));
     lib.recoverBranch(_hash, abi.encodePacked(_flag, _sufix));
   }
 
   function test_recover(bytes32 _subdigest, uint256 _pk, uint32 _checkpoint, uint16 _threshold, uint8 _weight) external {
-    _pk = boundPk(_pk);
+    boundPk(_pk);
 
     bytes memory signature = signAndPack(_pk, _subdigest, 1);
     address addr = vm.addr(_pk);

--- a/foundry_test/modules/commons/submodules/auth/SequenceDynamicSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceDynamicSig.t.sol
@@ -25,7 +25,7 @@ contract SequenceDynamicSigTest is AdvTest {
   }
 
   function test_recover_ignoreFirstByte(uint8 _first, bytes32 _subdigest, uint256 _pk, uint16 _threshold, uint32 _checkpoint, uint8 _weight) external {
-    _pk = boundPk(_pk);
+    boundPk(_pk);
 
     bytes memory encoded = abi.encodePacked(_threshold, _checkpoint, uint8(0), _weight, signAndPack(_pk, _subdigest, 1));
 

--- a/foundry_test/modules/commons/submodules/auth/SequenceNoChainIdSig.t.sol
+++ b/foundry_test/modules/commons/submodules/auth/SequenceNoChainIdSig.t.sol
@@ -26,8 +26,8 @@ contract SequenceNoChainIdSigTest is AdvTest {
   }
 
   function test_subdigest_DiffAddress(bytes32 _digest, address _addr1, address _addr2) external {
-    _addr1 = boundNoSys(_addr1);
-    _addr2 = boundNoSys(_addr2);
+    boundNoContract(boundNoSys(_addr1));
+    boundNoContract(boundNoSys(_addr2));
 
     vm.etch(_addr1, address(lib).code);
     vm.etch(_addr2, address(lib).code);

--- a/foundry_test/utils/LibAddress.t.sol
+++ b/foundry_test/utils/LibAddress.t.sol
@@ -8,7 +8,7 @@ import "foundry_test/base/AdvTest.sol";
 
 contract LibAddressTest is AdvTest {
   function test_isContract(address _addr, bytes calldata _code) external {
-    _addr = boundNoSys(_addr);
+    boundNoSys(_addr);
 
     vm.etch(_addr, _code);
     assertEq(LibAddress.isContract(_addr), _code.length > 0);


### PR DESCRIPTION
Improves test stability when fuzzing by:
* Adding checks for code at addresses
* Adding checks for ether at addresses
* Restarting the test with new vars when an assumption isn't met
* Bumped forge version
