### PR TITLE
Add Trust and TrustFactory Contracts for waas Recovery

### DIFF
--- a/contracts/trust/Trust.sol
+++ b/contracts/trust/Trust.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.18;
+
+import "../interfaces/IERC1271Wallet.sol";
+import "../utils/SignatureValidator.sol";
+
+function absDiff(uint256 a, uint256 b) pure returns (bool, uint256) {
+  if (a > b) {
+    return (true, a - b);
+  }
+
+  return (false, b - a);
+}
+
+contract Trust is IERC1271Wallet {
+  error UnlockInThePast(uint256 _unlocksAt, uint256 _elapsed);
+  error UnlockTooEarly(uint256 _unlocksAt, uint256 _diff);
+
+  error NotOwner(address _sender);
+  error NotUnlocked(uint256 _unlocksAt);
+  error FailedTransaction(address payable _to, uint256 _value, bytes _data, bytes _result);
+
+  error EmptySignature();
+  error InvalidSignatureFlag(bytes _signature, bytes1 _flag);
+  error InvalidSignature(bytes32 _hash, bytes32 _rehash, address _signer, bytes _signature);
+
+  event SetUnlocksAt(uint256 _unlocksAt);
+  event SentTransaction(address payable _to, uint256 _value, bytes _data, bytes _result);
+
+  address immutable public owner;
+  address immutable public beneficiary;
+  uint256 immutable public duration;
+
+  uint256 public unlocksAt = type(uint256).max;
+
+  constructor (
+    address _owner,
+    address _beneficiary,
+    uint256 _duration
+  ) {
+    owner = _owner;
+    beneficiary = _beneficiary;
+    duration = _duration;
+  }
+
+  modifier onlyAllowed() {
+    if (msg.sender != owner) {
+      if (msg.sender != beneficiary) {
+        revert NotOwner(msg.sender);
+      }
+
+      if (isLocked()) {
+        revert NotUnlocked(unlocksAt);
+      }
+    }
+
+    _;
+  }
+
+  modifier onlyMember() {
+    if (msg.sender != owner && msg.sender != beneficiary) {
+      revert NotOwner(msg.sender);
+    }
+
+    _;
+  }
+
+  function isLocked() public view returns (bool) {
+    return block.timestamp < unlocksAt;
+  }
+
+  function setUnlocksAt(uint256 _unlocksAt) external onlyMember {
+    // Diff between the current time and the unlock time must be
+    // greater than the duration of the trust
+    (bool isPast, uint256 elapsed) = absDiff(block.timestamp, _unlocksAt);
+    if (isPast) {
+      revert UnlockInThePast(_unlocksAt, elapsed);
+    }
+
+    if (elapsed < duration) {
+      revert UnlockTooEarly(_unlocksAt, elapsed);
+    }
+
+    emit SetUnlocksAt(_unlocksAt);
+    unlocksAt = _unlocksAt;
+  }
+
+  function sendTransaction(
+    address payable _to,
+    uint256 _value,
+    bytes calldata _data
+  ) external onlyAllowed returns (bytes memory) {
+    (bool success, bytes memory result) = _to.call{value: _value}(_data);
+
+    if (!success) {
+      revert FailedTransaction(_to, _value, _data, result);
+    }
+
+    emit SentTransaction(_to, _value, _data, result);
+    return result;
+  }
+
+  bytes4 internal constant SELECTOR_ERC1271_BYTES_BYTES = 0x20c13b0b;
+  bytes4 internal constant SELECTOR_ERC1271_BYTES32_BYTES = 0x1626ba7e;
+
+  function isValidSignature(
+    bytes calldata _data,
+    bytes calldata _signature
+  ) external view returns (bytes4) {
+    bytes4 res = Trust(payable(address((this)))).isValidSignature(
+      keccak256(_data),
+      _signature
+    );
+
+    if (res == SELECTOR_ERC1271_BYTES32_BYTES) {
+      return SELECTOR_ERC1271_BYTES_BYTES;
+    }
+
+    return bytes4(0);
+  }
+
+  function isValidSignature(
+    bytes32 _hash,
+    bytes calldata _signature
+  ) external view returns (bytes4) {
+    if (_signature.length == 0) {
+      revert EmptySignature();
+    }
+
+    // If last byte is 0x00 we use the owner
+    // if 0x01 we use the beneficiary
+    address signer;
+
+    if (_signature[_signature.length - 1] == 0x00) {
+      signer = owner;
+    } else if (_signature[_signature.length - 1] == 0x01) {
+      signer = beneficiary;
+    } else {
+      revert InvalidSignatureFlag(_signature, _signature[_signature.length - 1]);
+    }
+
+    if (signer != owner && isLocked()) {
+      revert NotUnlocked(unlocksAt);
+    }
+
+    // Re-hash the hash adding the address of the trust
+    // otherwise the signature will be valid for any trust
+    bytes32 rehash = keccak256(abi.encodePacked(address(this), _hash));
+
+    // Validate the signature
+    if (!SignatureValidator.isValidSignature(rehash, signer, _signature[0:_signature.length - 1])) {
+      revert InvalidSignature(_hash, rehash, signer, _signature[0:_signature.length - 1]);
+    }
+
+    return SELECTOR_ERC1271_BYTES32_BYTES;
+  }
+
+  receive() external payable {}
+  fallback() external payable {}
+}

--- a/contracts/trust/Trust.sol
+++ b/contracts/trust/Trust.sol
@@ -112,11 +112,8 @@ contract Trust is IERC1271Wallet {
       _signature
     );
 
-    if (res == SELECTOR_ERC1271_BYTES32_BYTES) {
-      return SELECTOR_ERC1271_BYTES_BYTES;
-    }
-
-    return bytes4(0);
+    assert(res == SELECTOR_ERC1271_BYTES32_BYTES);
+    return SELECTOR_ERC1271_BYTES_BYTES;
   }
 
   function isValidSignature(

--- a/contracts/trust/TrustFactory.sol
+++ b/contracts/trust/TrustFactory.sol
@@ -5,8 +5,6 @@ import "./Trust.sol";
 
 
 contract TrustFactory {
-  error ErrorDeployingTrust(address _owner, address _beneficiary, uint256 _duration);
-
   function addressOf(
     address _owner,
     address _beneficiary,

--- a/contracts/trust/TrustFactory.sol
+++ b/contracts/trust/TrustFactory.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.18;
+
+import "./Trust.sol";
+
+
+contract TrustFactory {
+  error ErrorDeployingTrust(address _owner, address _beneficiary, uint256 _duration);
+
+  function addressOf(
+    address _owner,
+    address _beneficiary,
+    uint256 _duration
+  ) external view returns (address) {
+    return address(uint160(uint(keccak256(abi.encodePacked(
+      bytes1(0xff),
+      address(this),
+      bytes32(0),
+      keccak256(abi.encodePacked(
+        type(Trust).creationCode,
+        abi.encode(_owner, _beneficiary, _duration)
+      ))
+    )))));
+  }
+
+  function deploy(
+    address _owner,
+    address _beneficiary,
+    uint256 _duration
+  ) external returns (address) {
+    Trust trust = new Trust{ salt: bytes32(0) }( _owner, _beneficiary, _duration);
+
+    if (address(trust) == address(0)) {
+      revert ErrorDeployingTrust(_owner, _beneficiary, _duration);
+    }
+
+    return address(trust);
+  }
+}

--- a/contracts/trust/TrustFactory.sol
+++ b/contracts/trust/TrustFactory.sol
@@ -5,6 +5,10 @@ import "./Trust.sol";
 
 
 contract TrustFactory {
+  function trustCreationCode() external pure returns (bytes memory) {
+    return type(Trust).creationCode;
+  }
+
   function addressOf(
     address _owner,
     address _beneficiary,

--- a/contracts/trust/TrustFactory.sol
+++ b/contracts/trust/TrustFactory.sol
@@ -27,13 +27,7 @@ contract TrustFactory {
     address _owner,
     address _beneficiary,
     uint256 _duration
-  ) external returns (address) {
-    Trust trust = new Trust{ salt: bytes32(0) }( _owner, _beneficiary, _duration);
-
-    if (address(trust) == address(0)) {
-      revert ErrorDeployingTrust(_owner, _beneficiary, _duration);
-    }
-
-    return address(trust);
+  ) external returns (Trust) {
+    return new Trust{ salt: bytes32(0) }( _owner, _beneficiary, _duration);
   }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,6 @@ src = 'contracts'
 out = 'foundry_artifacts'
 libs = ["node_modules", "lib"]
 test = 'foundry_test'
+
 ffi = true
+max_test_rejects = 2048000

--- a/foundry_test/trust/Trust.t.sol
+++ b/foundry_test/trust/Trust.t.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.18;
+
+import "contracts/trust/Trust.sol";
+
+import "foundry_test/base/AdvTest.sol";
+
+function min(uint256 a, uint256 b) pure returns (uint256) {
+  return a < b ? a : b;
+}
+
+contract MockFail {
+  bytes revertData;
+
+  constructor (bytes memory _revertData) {
+    revertData = _revertData;
+  }
+
+  fallback() external payable {
+    bytes memory rd = revertData;
+    assembly {
+      revert(add(rd, 0x20), mload(rd))
+    }
+  }
+}
+
+contract TrustTest is AdvTest {
+  Trust private trust;
+
+  function test_start_locked(uint256 _ownerPk, uint256 _beneficiaryPk, uint256 _duration) external {
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+    assertEq(trust.isLocked(), true);
+  }
+
+  function test_fail_schedule_unlock_too_early(uint256 _ownerPk, uint256 _beneficiaryPk, uint256 _duration, uint256 _schedule) external {
+    vm.assume(_duration != 0);
+
+    _schedule = bound(_schedule, 0, _duration - 1);
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_ownerPk)));
+    vm.expectRevert(abi.encodeWithSignature('UnlockTooEarly(uint256,uint256)', block.timestamp + _schedule, _schedule));
+    trust.setUnlocksAt(block.timestamp + _schedule);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    vm.expectRevert(abi.encodeWithSignature('UnlockTooEarly(uint256,uint256)', block.timestamp + _schedule, _schedule));
+    trust.setUnlocksAt(block.timestamp + _schedule);
+  }
+
+  function test_fail_schedule_in_the_past(uint256 _ownerPk, uint256 _beneficiaryPk, uint256 _duration, uint256 _schedule) external {
+    _schedule = bound(_schedule, 1, block.timestamp);
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_ownerPk)));
+    vm.expectRevert(abi.encodeWithSignature('UnlockInThePast(uint256,uint256)', block.timestamp - _schedule, _schedule));
+    trust.setUnlocksAt(block.timestamp - _schedule);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    vm.expectRevert(abi.encodeWithSignature('UnlockInThePast(uint256,uint256)', block.timestamp - _schedule, _schedule));
+    trust.setUnlocksAt(block.timestamp - _schedule);
+  }
+
+  function test_fail_schedule_non_allowed(uint256 _ownerPk, uint256 _beneficiaryPk, uint256 _badActorpk, uint256 _duration, uint256 _unlockAt) external {
+    _badActorpk = boundDiff(boundPk(_badActorpk), boundPk(_ownerPk), boundPk(_beneficiaryPk));
+
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_badActorpk)));
+    vm.expectRevert(abi.encodeWithSignature('NotOwner(address)', vm.addr(boundPk(_badActorpk))));
+    trust.setUnlocksAt(_unlockAt);
+  }
+
+  event SetUnlocksAt(uint256 _unlocksAt);
+
+  function test_schedule_unlock(uint256 _ownerPk, uint256 _beneficiaryPk, bool _asOwner, uint256 _duration, uint256 _unlockAt) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_asOwner ? _ownerPk : _beneficiaryPk)));
+
+    vm.expectEmit(true, true, true, true, address(trust));
+    emit SetUnlocksAt(_unlockAt);
+
+    trust.setUnlocksAt(_unlockAt);
+    assertEq(trust.unlocksAt(), _unlockAt);
+  }
+
+  function test_wait_for_unlock(uint256 _ownerPk, uint256 _beneficiaryPk, uint256 _duration, uint256 _unlockAt, uint256 _extra) external {
+    vm.assume(block.timestamp != type(uint256).max);
+
+    _duration = bound(_duration, 0, (type(uint256).max - 1) - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max - 1);
+    _extra    = bound(_extra, 0, type(uint256).max - _unlockAt);
+
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    trust.setUnlocksAt(_unlockAt);
+
+    if (_duration > 0) {
+      vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+      assertEq(trust.isLocked(), true);
+    }
+
+    vm.warp(_unlockAt + _extra);
+    assertEq(trust.isLocked(), false);
+  }
+
+  function gen_and_unlock(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _extra
+  ) internal returns (Trust) {
+    _duration = bound(_duration, 0, (type(uint256).max - 1) - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max - 1);
+    _extra    = bound(_extra, 0, type(uint256).max - _unlockAt);
+
+    trust = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    trust.setUnlocksAt(_unlockAt);
+
+    vm.warp(_unlockAt + _extra);
+
+    return trust;
+  }
+
+  event SentTransaction(address _to, uint256 _value, bytes _data, bytes _result);
+
+  function test_send_transaction_after_unlock(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    bool    _ownerSender,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _extra,
+    uint256 _toPk,
+    uint256 _value,
+    bytes calldata _data
+  ) external {
+    Trust t = gen_and_unlock(
+      _ownerPk,
+      _beneficiaryPk,
+      _duration,
+      _unlockAt,
+      _extra
+    );
+
+    vm.deal(address(this), _value);
+    payable(address((t))).transfer(_value);
+
+    vm.prank(vm.addr(boundPk(_ownerSender ? _ownerPk : _beneficiaryPk)));
+    vm.expectCall(vm.addr(boundPk(_toPk)), _value, _data);
+
+    vm.expectEmit(true, true, true, true, address(t));
+    emit SentTransaction(vm.addr(boundPk(_toPk)), _value, _data, new bytes(0));
+
+    t.sendTransaction(payable(vm.addr(boundPk(_toPk))), _value, _data);
+
+    assertEq(vm.addr(boundPk(_toPk)).balance, _value);
+  }
+
+  function test_send_transaction_pre_unlock_as_owner(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _toPk,
+    uint256 _value,
+    bytes calldata _data
+  ) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.deal(address(this), _value);
+    payable(address((t))).transfer(_value);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    vm.prank(vm.addr(boundPk(_ownerPk)));
+    vm.expectCall(vm.addr(boundPk(_toPk)), _value, _data);
+    t.sendTransaction(payable(vm.addr(boundPk(_toPk))), _value, _data);
+  }
+
+  function test_fail_send_transaction_pre_unlock_as_beneficiary(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _toPk,
+    uint256 _value,
+    uint256 _elapsed,
+    bytes calldata _data
+  ) external {
+    _duration = bound(_duration, 1, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+    _elapsed  = bound(_elapsed, 0, (_unlockAt - block.timestamp) - 1);
+
+    vm.assume(vm.addr(boundPk(_ownerPk)) != vm.addr(boundPk(_beneficiaryPk)));
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.deal(address(this), _value);
+    payable(address((t))).transfer(_value);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    vm.warp(block.timestamp + _elapsed);
+
+    assertEq(t.isLocked(), true);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    vm.expectRevert(abi.encodeWithSignature('NotUnlocked(uint256)', _unlockAt));
+    t.sendTransaction(payable(vm.addr(boundPk(_toPk))), _value, _data);
+  }
+
+  function test_fail_send_transaction_non_allowed(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _badActorPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _elapsed,
+    uint256 _toPk,
+    uint256 _value,
+    bytes calldata _data
+  ) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+    _elapsed  = bound(_elapsed, 0, type(uint256).max - block.timestamp);
+
+    _badActorPk = boundDiff(boundPk(_badActorPk), boundPk(_ownerPk), boundPk(_beneficiaryPk));
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.deal(address(this), _value);
+    payable(address((t))).transfer(_value);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    vm.warp(block.timestamp + _elapsed);
+
+    vm.prank(vm.addr(boundPk(_badActorPk)));
+    vm.expectRevert(abi.encodeWithSignature('NotOwner(address)', vm.addr(boundPk(_badActorPk))));
+    t.sendTransaction(payable(vm.addr(boundPk(_toPk))), _value, _data);
+  }
+
+  function test_fail_bubble_up_fail(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    bool    _ownerSender,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _value,
+    uint256 _extra,
+    bytes calldata _data,
+    bytes calldata _revertData
+  ) external {
+    address sender = vm.addr(boundPk(_ownerSender ? _ownerPk : _beneficiaryPk));
+
+    Trust t = gen_and_unlock(
+      _ownerPk,
+      _beneficiaryPk,
+      _duration,
+      _unlockAt,
+      _extra
+    );
+
+    vm.deal(address(this), _value);
+    payable(address((t))).transfer(_value);
+
+    MockFail mf = new MockFail(_revertData);
+
+    vm.prank(sender);
+
+    vm.expectRevert(abi.encodeWithSignature(
+      "FailedTransaction(address,uint256,bytes,bytes)",
+      address(mf),
+      _value,
+      _data,
+      _revertData
+    ));
+
+    t.sendTransaction(payable(address(mf)), _value, _data);
+  }
+
+  function test_isValidSignature(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint256 _extra,
+    bool _signedByOwner,
+    bytes calldata _message
+  ) external {
+    uint256 signerPk = boundPk(_signedByOwner ? _ownerPk : _beneficiaryPk);
+
+    Trust t = gen_and_unlock(
+      _ownerPk,
+      _beneficiaryPk,
+      _duration,
+      _unlockAt,
+      _extra
+    );
+
+    bytes32 rawHash = keccak256(_message);
+    bytes32 finalHash = keccak256(abi.encodePacked(address(t), rawHash));
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, finalHash);
+
+    bytes memory sig = abi.encodePacked(r, s, v, uint8(1), _signedByOwner ? bytes1(0x00) : bytes1(0x01));
+
+    assertEq(t.isValidSignature(rawHash, sig), bytes4(0x1626ba7e));
+    assertEq(t.isValidSignature(_message, sig), bytes4(0x20c13b0b));
+  }
+
+  function test_isValidSignature_pre_unlock_as_owner(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    bytes calldata _message
+  ) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    bytes32 rawHash = keccak256(_message);
+    bytes32 finalHash = keccak256(abi.encodePacked(address(t), rawHash));
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(boundPk(_ownerPk), finalHash);
+
+    bytes memory sig = abi.encodePacked(r, s, v, uint8(1), bytes1(0x00));
+
+    assertEq(t.isValidSignature(rawHash, sig), bytes4(0x1626ba7e));
+    assertEq(t.isValidSignature(_message, sig), bytes4(0x20c13b0b));
+  }
+
+  function test_fail_isValidSignature_emptySignature(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    bytes calldata _message
+  ) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    bytes memory sig = new bytes(0);
+
+    vm.expectRevert(abi.encodeWithSignature('EmptySignature()'));
+    t.isValidSignature(_message, sig);
+
+    vm.expectRevert(abi.encodeWithSignature('EmptySignature()'));
+    t.isValidSignature(keccak256(_message), sig);
+  }
+
+  function test_fail_isValidSignature_wrongSignatureFlag(
+    uint256 _ownerPk,
+    uint256 _beneficiaryPk,
+    uint256 _duration,
+    uint256 _unlockAt,
+    uint8 _signerFlag,
+    bytes calldata _signature,
+    bytes calldata _message
+  ) external {
+    _duration = bound(_duration, 0, type(uint256).max - block.timestamp);
+    _unlockAt = bound(_unlockAt, block.timestamp + _duration, type(uint256).max);
+    _signerFlag = uint8(bound(_signerFlag, 2, type(uint8).max));
+
+    Trust t = new Trust(vm.addr(boundPk(_ownerPk)), vm.addr(boundPk(_beneficiaryPk)), _duration);
+
+    vm.prank(vm.addr(boundPk(_beneficiaryPk)));
+    t.setUnlocksAt(_unlockAt);
+
+    bytes memory sig = abi.encodePacked(_signature, _signerFlag);
+
+    vm.expectRevert(abi.encodeWithSignature('InvalidSignatureFlag(bytes,bytes1)', sig, bytes1(_signerFlag)));
+    t.isValidSignature(_message, sig);
+
+    vm.expectRevert(abi.encodeWithSignature('InvalidSignatureFlag(bytes,bytes1)', sig, bytes1(_signerFlag)));
+    t.isValidSignature(keccak256(_message), sig);
+  }
+}

--- a/foundry_test/trust/TrustFactory.t.sol
+++ b/foundry_test/trust/TrustFactory.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.18;
+
+import "contracts/trust/TrustFactory.sol";
+
+import "foundry_test/base/AdvTest.sol";
+
+contract TrustFactoryTest is AdvTest {
+  TrustFactory private factory;
+
+  function setUp() external {
+    factory = new TrustFactory();
+  }
+
+  function test_create_trust(address _owner, address _beneficiary, uint256 _duration) external {
+    Trust trust = factory.deploy(_owner, _beneficiary, _duration);
+    address trustAddress = address(trust);
+
+    assertEq(trust.owner(), _owner);
+    assertEq(trust.beneficiary(), _beneficiary);
+    assertEq(trust.duration(), _duration);
+
+    uint256 codeSize; assembly { codeSize := extcodesize(trustAddress) }
+    assertGt(codeSize, 0);
+  }
+
+  function test_predict_address(address _owner, address _beneficiary, uint256 _duration) external {
+    address expected = factory.addressOf(_owner, _beneficiary, _duration);
+    address actual = address(factory.deploy(_owner, _beneficiary, _duration));
+    assertEq(actual, expected);
+  }
+
+  function test_fail_deploy_twice(address _owner, address _beneficiary, uint256 _duration) external {
+    factory.deploy(_owner, _beneficiary, _duration);
+    vm.expectRevert();
+    factory.deploy(_owner, _beneficiary, _duration);
+  }
+
+  function test_fail_deploy_low_gas(address _owner, address _beneficiary, uint256 _duration, uint256 _gas) external {
+    _gas = bound(_gas, 21000, block.gaslimit);
+    try factory.deploy{ gas: _gas }(_owner, _beneficiary, _duration) returns (Trust trust) {
+      address trustAddress = address(trust);
+      // The address should have code, and never be the zero address
+      assertNotEq(trustAddress, address(0));
+      uint256 codeSize; assembly { codeSize := extcodesize(trustAddress) }
+      assertGt(codeSize, 0);
+    } catch {
+      // Ignore errors from low gas
+    }
+  }
+}

--- a/networks/polygon.json
+++ b/networks/polygon.json
@@ -21,6 +21,6 @@
   },
   {
     "contractName": "TrustFactory",
-    "address": "0x8E7e68e74065C561480d0DD5C13794B5dCF0DFda"
+    "address": "0x4483FaA9dEEDd6D6FaCFee9c686f1E394A1280f9"
   }
 ]

--- a/networks/polygon.json
+++ b/networks/polygon.json
@@ -18,5 +18,9 @@
   {
     "contractName": "SequenceUtils",
     "address": "0xdbbFa3cB3B087B64F4ef5E3D20Dda2488AA244e6"
+  },
+  {
+    "contractName": "TrustFactory",
+    "address": "0x8E7e68e74065C561480d0DD5C13794B5dCF0DFda"
   }
 ]

--- a/utils/config-loader.ts
+++ b/utils/config-loader.ts
@@ -26,8 +26,7 @@ export const getEnvConfig = (env: string) => {
   const envLoad = dotenv.config({ path: envFile })
 
   if (envLoad.error) {
-    console.warn('No config found, using default')
-    return { ETH_MNEMONIC: ethers.Wallet.createRandom().mnemonic.phrase }
+    return { ETH_MNEMONIC: "client vendor advice erosion deny cute tree fatal fuel bless simple speed" }
   }
 
   return envLoad.parsed || {}

--- a/utils/deploy-contracts.ts
+++ b/utils/deploy-contracts.ts
@@ -1,5 +1,4 @@
 import { network, run, tenderly, ethers as hethers } from 'hardhat'
-import * as _ from 'lodash'
 import ora from 'ora'
 
 import {
@@ -7,7 +6,8 @@ import {
   SequenceUtils__factory,
   MainModuleUpgradable__factory,
   GuestModule__factory,
-  Factory__factory
+  Factory__factory,
+  TrustFactory__factory
 } from '../gen/typechain'
 
 import { BigNumber, ContractFactory, ethers } from 'ethers'
@@ -141,6 +141,7 @@ const main = async () => {
   const mainModule = await deploy("MainModule", MainModule__factory, walletFactory.address, mainModuleUpgradeable.address)
   const guestModule = await deploy("GuestModule", GuestModule__factory)
   const sequenceUtils = await deploy("SequenceUtils", SequenceUtils__factory)
+  const trustFactory = await deploy("TrustFactory", TrustFactory__factory)
 
   prompt.start(`writing deployment information to ${network.name}.json`)
   fs.writeFileSync(`./networks/${network.name}.json`, JSON.stringify(buildNetworkJson(
@@ -148,7 +149,8 @@ const main = async () => {
     { name: "MainModule", address: mainModule.address },
     { name: "MainModuleUpgradable", address: mainModuleUpgradeable.address },
     { name: "GuestModule", address: guestModule.address },
-    { name: "SequenceUtils", address: sequenceUtils.address }
+    { name: "SequenceUtils", address: sequenceUtils.address },
+    { name: "TrustFactory", address: trustFactory.address },
   ), null, 2))
   prompt.succeed()
 
@@ -159,6 +161,7 @@ const main = async () => {
   await attempVerify("MainModule", MainModule__factory, mainModule.address, walletFactory.address, mainModuleUpgradeable.address)
   await attempVerify("GuestModule", GuestModule__factory, guestModule.address)
   await attempVerify("SequenceUtils", SequenceUtils__factory, sequenceUtils.address)
+  await attempVerify("TrustFactory", TrustFactory__factory, trustFactory.address)
 
   prompt.succeed()
 }


### PR DESCRIPTION
Introduced `Trust.sol` and `TrustFactory.sol` contracts for the waas recovery flow. `Trust.sol` allows setting up time-locked trusts with transaction capabilities. `TrustFactory.sol` is designed to create counterfactual instances of Trust contracts. Both contracts are backed by comprehensive tests, covering 100% of the code.